### PR TITLE
fix shorcut key on macOS (temporary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Totally free application
 
 * **[Egaroucid](https://www.egaroucid.nyanyan.dev/en/) - GUI application**
   
-  * Desktop application for Windows
+  * Desktop application for Windows/ macOS
   * Japanese / English / Chinese
   * GUI with [Siv3D](https://github.com/Siv3D)
   

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Totally free application
 
 * **[Egaroucid](https://www.egaroucid.nyanyan.dev/en/) - GUI application**
   
-  * Desktop application for Windows/ macOS
+  * Desktop application for Windows / macOS
   * Japanese / English / Chinese
   * GUI with [Siv3D](https://github.com/Siv3D)
   

--- a/src/engine/util.hpp
+++ b/src/engine/util.hpp
@@ -273,4 +273,5 @@ bool is_valid_transcript(std::string transcript) {
         calc_flip(&flip, &board, coord);
         board.move_board(&flip);
     }
+    return true;
 }

--- a/src/gui/shortcut_key_setting_scene.hpp
+++ b/src/gui/shortcut_key_setting_scene.hpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Egaroucid Project
 
     @file shortcut_key_setting.hpp
@@ -20,6 +20,14 @@ std::vector<String> allow_multi_input_keys = {
     U"Ctrl",
     U"Shift",
     U"Alt"
+#ifdef __APPLE__
+    , U"Command",
+    U"Left Command",
+    U"Right Command",
+    U"Left Ctrl",
+    U"Left Shift",
+    U"Right Shift",
+#endif
 };
 
 class Shortcut_key_setting : public App::Scene {


### PR DESCRIPTION
macOSで同時押しのショートカットが設定できない問題を一時的に解決しました。
なぜかctrlキーなどを押すと2個分(Ctrl + Left Ctrlなど)判定してしまうのは直せていないので、タイトル通り一時的です。
macOSの場合のデフォルトのキー設定をセットしたいのですが、どこでセットされているでしょうか？
あとlanguage.jsonの修正もおそらく必要です(同時押し対応キーにCommandを追加します)
ビルドに失敗する問題(bool is_valid_transcriptが値を返さないパターンが存在する)を一応直しましたが、問題があれば戻しておいてください。