### PR TITLE
Improve YBWC helper task waiting (Vibe Kanban)

### DIFF
--- a/src/engine/thread_pool.hpp
+++ b/src/engine/thread_pool.hpp
@@ -11,8 +11,8 @@
 
 #pragma once
 #include <iostream>
+#include <deque>
 #include <future>
-#include <queue>
 #include <thread>
 #include <atomic>
 #include <functional>
@@ -42,7 +42,7 @@ class Thread_pool {
         int n_thread;
         //std::atomic<int> n_idle;
         int n_idle;
-        std::queue<std::pair<thread_id_t, std::function<void()>>> tasks{};
+        std::deque<std::pair<thread_id_t, std::function<void()>>> tasks{};
         std::unique_ptr<std::thread[]> threads;
         std::condition_variable condition;
 
@@ -134,6 +134,42 @@ class Thread_pool {
             return n_using_thread[id];
         }
 
+        bool try_execute_one(thread_id_t preferred_id) {
+            std::pair<thread_id_t, std::function<void()>> task_pair;
+            {
+                std::unique_lock<std::mutex> lock(mtx);
+                if (tasks.empty()) {
+                    return false;
+                }
+                auto it = tasks.end();
+                if (preferred_id != THREAD_ID_NONE) {
+                    for (auto itr = tasks.begin(); itr != tasks.end(); ++itr) {
+                        if (itr->first == preferred_id) {
+                            it = itr;
+                            break;
+                        }
+                    }
+                }
+                if (it == tasks.end()) {
+                    if (preferred_id != THREAD_ID_NONE) {
+                        return false;
+                    }
+                    it = tasks.begin();
+                }
+                task_pair = std::move(*it);
+                tasks.erase(it);
+                ++n_idle;
+            }
+            if (task_pair.second) {
+                task_pair.second();
+                if (task_pair.first != THREAD_ID_NONE) {
+                    n_using_thread[task_pair.first].fetch_sub(1);
+                }
+                return true;
+            }
+            return false;
+        }
+
         /*
         void reset_unavailable() {
             if (n_idle == n_thread && n_using_tasks.load() == 0) {
@@ -217,7 +253,7 @@ class Thread_pool {
                     std::unique_lock<std::mutex> lock(mtx);
                     if (n_idle > 0 && n_using_thread[id] < max_thread_size[id]) {
                         pushed = true;
-                        tasks.push(std::make_pair(id, std::function<void()>(task)));
+                        tasks.emplace_back(id, std::function<void()>(task));
                         --n_idle;
                         condition.notify_one();
                         if (id != THREAD_ID_NONE) {
@@ -243,7 +279,7 @@ class Thread_pool {
                     if (!tasks.empty()) {
                         id = tasks.front().first;
                         task = std::move(tasks.front().second);
-                        tasks.pop();
+                        tasks.pop_front();
                     }
                 }
                 if (task) {

--- a/src/engine/ybwc.hpp
+++ b/src/engine/ybwc.hpp
@@ -35,6 +35,37 @@ constexpr int YBWC_PUSHED = 124;
 int nega_alpha_ordering_nws(Search *search, int alpha, const int depth, const bool skipped, uint64_t legal, const bool is_end_search, std::vector<bool*> &searchings);
 inline bool is_searching(std::vector<bool*> &searchings);
 
+inline bool ybwc_get_finished_task(std::vector<std::future<Parallel_task>> &parallel_tasks, Parallel_task *task_result) {
+    for (std::future<Parallel_task> &task: parallel_tasks) {
+        if (task.valid() && task.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+            *task_result = task.get();
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool ybwc_wait_task_with_help(std::vector<std::future<Parallel_task>> &parallel_tasks, thread_id_t thread_id, bool use_help, Parallel_task *task_result) {
+    while (true) {
+        if (ybwc_get_finished_task(parallel_tasks, task_result)) {
+            return true;
+        }
+        bool has_valid_task = false;
+        for (std::future<Parallel_task> &task: parallel_tasks) {
+            if (task.valid()) {
+                has_valid_task = true;
+                break;
+            }
+        }
+        if (!has_valid_task) {
+            return false;
+        }
+        if (!use_help || !thread_pool.try_execute_one(thread_id)) {
+            std::this_thread::yield();
+        }
+    }
+}
+
 /*
     @brief Wrapper for parallel NWS (Null Window Search)
 
@@ -161,30 +192,23 @@ inline void ybwc_search_young_brothers_nws(Search *search, int alpha, int *v, in
     Parallel_task task_result;
 #if USE_YBWC_SPLITTED_TASK_TERMINATION
     if (is_searching(searchings) && *v <= alpha && running_count >= 2 && ((is_end_search && depth >= 28) || (!is_end_search && depth >= 24))) {
-        for (std::future<Parallel_task> &task: parallel_tasks) {
-            if (task.valid()) {
-                if (task.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-                    task_result = task.get();
-                    --running_count;
-                    search->n_nodes += task_result.n_nodes;
-                    if (task_result.value != SCORE_UNDEFINED) {
-                        if (*v < task_result.value) {
-                            *v = task_result.value;
-                            *best_move = move_list[task_result.move_idx].flip.pos;
-                        }
-                        move_list[task_result.move_idx].flip.flip = 0;
-                        ++n_searched;
-                    }
+        while (ybwc_get_finished_task(parallel_tasks, &task_result)) {
+            --running_count;
+            search->n_nodes += task_result.n_nodes;
+            if (task_result.value != SCORE_UNDEFINED) {
+                if (*v < task_result.value) {
+                    *v = task_result.value;
+                    *best_move = move_list[task_result.move_idx].flip.pos;
                 }
+                move_list[task_result.move_idx].flip.flip = 0;
+                ++n_searched;
             }
         }
         if (is_searching(searchings) && *v <= alpha && running_count >= 2) {
             n_searching = false; // terminate splitted tasks
-            for (std::future<Parallel_task> &task: parallel_tasks) {
-                if (task.valid()) {
-                    task_result = task.get();
-                    search->n_nodes += task_result.n_nodes;
-                }
+            while (running_count > 0 && ybwc_wait_task_with_help(parallel_tasks, search->thread_id, !is_end_search, &task_result)) {
+                --running_count;
+                search->n_nodes += task_result.n_nodes;
             }
             searchings.pop_back(); // pop n_searching
             if (is_searching(searchings)) {
@@ -194,18 +218,16 @@ inline void ybwc_search_young_brothers_nws(Search *search, int alpha, int *v, in
         }
     }
 #endif
-    for (std::future<Parallel_task> &task: parallel_tasks) {
-        if (task.valid()) {
-            task_result = task.get();
-            search->n_nodes += task_result.n_nodes;
-            if (task_result.value != SCORE_UNDEFINED) {
-                if (*v < task_result.value) {
-                    *v = task_result.value;
-                    *best_move = move_list[task_result.move_idx].flip.pos;
-                    // if (alpha < task_result.value) {
-                    //     n_searching = false;
-                    // }
-                }
+    while (running_count > 0 && ybwc_wait_task_with_help(parallel_tasks, search->thread_id, !is_end_search, &task_result)) {
+        --running_count;
+        search->n_nodes += task_result.n_nodes;
+        if (task_result.value != SCORE_UNDEFINED) {
+            if (*v < task_result.value) {
+                *v = task_result.value;
+                *best_move = move_list[task_result.move_idx].flip.pos;
+                // if (alpha < task_result.value) {
+                //     n_searching = false;
+                // }
             }
         }
     }
@@ -263,30 +285,23 @@ inline void ybwc_search_young_brothers_nws(Search *search, int alpha, int *v, in
     Parallel_task task_result;
 #if USE_YBWC_SPLITTED_TASK_TERMINATION
     if (is_searching(searchings) && *v <= alpha && running_count >= 2 && ((is_end_search && depth >= 28) || (!is_end_search && depth >= 24))) {
-        for (std::future<Parallel_task> &task: parallel_tasks) {
-            if (task.valid()) {
-                if (task.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-                    task_result = task.get();
-                    --running_count;
-                    search->n_nodes += task_result.n_nodes;
-                    if (task_result.value != SCORE_UNDEFINED) {
-                        if (*v < task_result.value) {
-                            *v = task_result.value;
-                            *best_move = move_list[task_result.move_idx].flip.pos;
-                        }
-                        move_list[task_result.move_idx].flip.flip = 0;
-                        ++n_searched;
-                    }
+        while (ybwc_get_finished_task(parallel_tasks, &task_result)) {
+            --running_count;
+            search->n_nodes += task_result.n_nodes;
+            if (task_result.value != SCORE_UNDEFINED) {
+                if (*v < task_result.value) {
+                    *v = task_result.value;
+                    *best_move = move_list[task_result.move_idx].flip.pos;
                 }
+                move_list[task_result.move_idx].flip.flip = 0;
+                ++n_searched;
             }
         }
         if (is_searching(searchings) && *v <= alpha && running_count >= 2) {
             n_searching = false; // terminate splitted tasks
-            for (std::future<Parallel_task> &task: parallel_tasks) {
-                if (task.valid()) {
-                    task_result = task.get();
-                    search->n_nodes += task_result.n_nodes;
-                }
+            while (running_count > 0 && ybwc_wait_task_with_help(parallel_tasks, search->thread_id, !is_end_search, &task_result)) {
+                --running_count;
+                search->n_nodes += task_result.n_nodes;
             }
             searchings.pop_back(); // pop n_searching
             if (is_searching(searchings)) {
@@ -296,18 +311,16 @@ inline void ybwc_search_young_brothers_nws(Search *search, int alpha, int *v, in
         }
     }
 #endif
-    for (std::future<Parallel_task> &task: parallel_tasks) {
-        if (task.valid()) {
-            task_result = task.get();
-            search->n_nodes += task_result.n_nodes;
-            if (task_result.value != SCORE_UNDEFINED) {
-                if (*v < task_result.value) {
-                    *v = task_result.value;
-                    *best_move = move_list[task_result.move_idx].flip.pos;
-                    // if (alpha < task_result.value) {
-                    //     n_searching = false;
-                    // }
-                }
+    while (running_count > 0 && ybwc_wait_task_with_help(parallel_tasks, search->thread_id, !is_end_search, &task_result)) {
+        --running_count;
+        search->n_nodes += task_result.n_nodes;
+        if (task_result.value != SCORE_UNDEFINED) {
+            if (*v < task_result.value) {
+                *v = task_result.value;
+                *best_move = move_list[task_result.move_idx].flip.pos;
+                // if (alpha < task_result.value) {
+                //     n_searching = false;
+                // }
             }
         }
     }
@@ -390,23 +403,20 @@ void ybwc_search_young_brothers(Search *search, int *alpha, int *beta, int *v, i
     if (running_count) {
         // thread_pool.start_idling();
         Parallel_task task_result;
-        for (std::future<Parallel_task> &task: parallel_tasks) {
-            if (task.valid()) {
-                task_result = task.get();
-                --running_count;
-                search->n_nodes += task_result.n_nodes;
-                if (task_result.value != SCORE_UNDEFINED) {
-                    if (*v < task_result.value) {
-                        *v = task_result.value;
-                        *best_move = move_list[task_result.move_idx].flip.pos;
-                    }
-                    if (*alpha < task_result.value) {
-                        next_alpha = std::max(next_alpha, task_result.value);
-                        research_idxes.emplace_back(task_result.move_idx);
-                    } else {
-                        move_list[task_result.move_idx].flip.flip = 0;
-                        ++n_searched;
-                    }
+        while (running_count > 0 && ybwc_wait_task_with_help(parallel_tasks, search->thread_id, !is_end_search, &task_result)) {
+            --running_count;
+            search->n_nodes += task_result.n_nodes;
+            if (task_result.value != SCORE_UNDEFINED) {
+                if (*v < task_result.value) {
+                    *v = task_result.value;
+                    *best_move = move_list[task_result.move_idx].flip.pos;
+                }
+                if (*alpha < task_result.value) {
+                    next_alpha = std::max(next_alpha, task_result.value);
+                    research_idxes.emplace_back(task_result.move_idx);
+                } else {
+                    move_list[task_result.move_idx].flip.flip = 0;
+                    ++n_searched;
                 }
             }
         }
@@ -492,23 +502,20 @@ void ybwc_search_young_brothers(Search *search, int *alpha, int *beta, int *v, i
     if (running_count) {
         // thread_pool.start_idling();
         Parallel_task task_result;
-        for (std::future<Parallel_task> &task: parallel_tasks) {
-            if (task.valid()) {
-                task_result = task.get();
-                --running_count;
-                search->n_nodes += task_result.n_nodes;
-                if (task_result.value != SCORE_UNDEFINED) {
-                    if (*v < task_result.value) {
-                        *v = task_result.value;
-                        *best_move = move_list[task_result.move_idx].flip.pos;
-                    }
-                    if (*alpha < task_result.value) {
-                        next_alpha = std::max(next_alpha, task_result.value);
-                        research_idxes.emplace_back(task_result.move_idx);
-                    } else {
-                        move_list[task_result.move_idx].flip.flip = 0;
-                        ++n_searched;
-                    }
+        while (running_count > 0 && ybwc_wait_task_with_help(parallel_tasks, search->thread_id, !is_end_search, &task_result)) {
+            --running_count;
+            search->n_nodes += task_result.n_nodes;
+            if (task_result.value != SCORE_UNDEFINED) {
+                if (*v < task_result.value) {
+                    *v = task_result.value;
+                    *best_move = move_list[task_result.move_idx].flip.pos;
+                }
+                if (*alpha < task_result.value) {
+                    next_alpha = std::max(next_alpha, task_result.value);
+                    research_idxes.emplace_back(task_result.move_idx);
+                } else {
+                    move_list[task_result.move_idx].flip.flip = 0;
+                    ++n_searched;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add a helper execution path to the thread pool so a thread waiting on YBWC work can execute queued tasks for the same search group instead of staying idle
- Rework YBWC task collection to poll completed tasks first and use helper-assisted waiting during midgame parallel search
- Keep the original split threshold for younger siblings and limit helper-assisted waiting away from endgame paths after tuning the surrounding YBWC behavior

## Why
Egaroucid was leaving too many cores idle during multithreaded search. The task for this branch was to improve parallel search utilization around YBWC, especially by letting cores that are waiting on split work help with other queued work, and then tune the surrounding YBWC behavior to find a faster configuration.

## What changed
- `src/engine/thread_pool.hpp`
  - Switched the internal task container to a deque so queued work can be selected and removed flexibly
  - Added `try_execute_one(thread_id_t preferred_id)` to let a waiting thread pull and run one queued task from the same search group
  - Preserved the existing thread accounting so helper-executed tasks still update per-thread usage counters correctly
- `src/engine/ybwc.hpp`
  - Added helpers to retrieve completed parallel tasks without blocking and to wait while optionally executing queued helper work
  - Replaced straight `future.get()` waits in YBWC result collection with helper-aware waiting loops
  - Kept `YBWC_N_YOUNGER_CHILD` at `1` after tuning, since that performed better than the more restrictive split setting
  - Restricted helper-assisted waiting to the midgame YBWC collection path, which was the best-performing balance found during tuning

## Important implementation details
- Helper execution is scoped by `thread_id`, so a waiting thread preferentially helps the same search subtree rather than arbitrary queued work
- The endgame path still uses the new non-blocking task collection logic, but does not use helper-assisted waiting because that configuration regressed performance during tuning
- The tuning outcome favored improving utilization without broadly increasing YBWC split restrictions

This PR was written using [Vibe Kanban](https://vibekanban.com)