### PR TITLE
Reuse TT bounds in move ordering with shallow NWS guard (Vibe Kanban)

### DIFF
--- a/src/engine/move_ordering.hpp
+++ b/src/engine/move_ordering.hpp
@@ -110,6 +110,8 @@ constexpr int MOVE_ORDERING_NWS_VALUE_OFFSET_ALPHA = 16;
 constexpr int MOVE_ORDERING_NWS_VALUE_OFFSET_BETA = 6;
 
 constexpr int MOVE_ORDERING_MPC_LEVEL = MPC_74_LEVEL;
+constexpr int MOVE_ORDERING_TT_REUSE_MIN_DEPTH = 1;
+constexpr int MOVE_ORDERING_NWS_TT_REUSE_MIN_DEPTH = 2;
 
 int nega_alpha_eval1(Search *search, int alpha, int beta, bool skipped);
 int nega_scout(Search *search, int alpha, int beta, const int depth, const bool skipped, uint64_t legal, const bool is_end_search, bool *searching);
@@ -254,7 +256,7 @@ inline void move_evaluate(Search *search, Flip_value *flip_value, int alpha, int
         flip_value->value += (MO_OFFSET_L_PM - get_weighted_n_moves(flip_value->n_legal)) * W_MOBILITY;
         flip_value->value += (MO_OFFSET_L_PM - get_potential_mobility(search->board.opponent, ~(search->board.player | search->board.opponent))) * W_POTENTIAL_MOBILITY;
         int child_value = SCORE_UNDEFINED;
-        const bool has_tt_value = depth > 0 && get_move_ordering_tt_value(search, search->board.hash(), depth, alpha, beta, &child_value);
+        const bool has_tt_value = depth >= MOVE_ORDERING_TT_REUSE_MIN_DEPTH && get_move_ordering_tt_value(search, search->board.hash(), depth, alpha, beta, &child_value);
         switch (depth) {
             case 0:
                 flip_value->value += (SCORE_MAX - mid_evaluate_diff(search)) * W_VALUE;
@@ -305,7 +307,7 @@ inline void move_evaluate_nws(Search *search, Flip_value *flip_value, int alpha,
         flip_value->n_legal = search->board.get_legal();
         flip_value->value += (MO_OFFSET_L_PM - get_weighted_n_moves(flip_value->n_legal)) * W_NWS_MOBILITY;
         int child_value = SCORE_UNDEFINED;
-        const bool has_tt_value = depth > 0 && get_move_ordering_tt_value(search, search->board.hash(), depth, alpha, beta, &child_value);
+        const bool has_tt_value = depth >= MOVE_ORDERING_NWS_TT_REUSE_MIN_DEPTH && get_move_ordering_tt_value(search, search->board.hash(), depth, alpha, beta, &child_value);
         switch (depth) {
             case 0:
                 flip_value->value += (SCORE_MAX - mid_evaluate_diff(search)) * W_NWS_VALUE;


### PR DESCRIPTION
## Summary
- reuse transposition table bounds during move ordering when the child position already has an exact value or a cutoff-producing bound
- avoid that shortcut in shallow null-window move ordering so the added lookup logic does not hurt throughput where the search is cheapest
- keep the change localized to `src/engine/move_ordering.hpp`

## What changed
This branch adds a helper that reads lower and upper bounds for the child node from the transposition table and turns them into a usable move-ordering score when the stored entry is already decisive for the current window. When that happens, move ordering can score the move without running the extra `nega_alpha_eval1` or `nega_scout` probe that was previously used.

The follow-up change adds separate minimum-depth thresholds for TT reuse in regular move ordering and null-window move ordering. Regular move ordering still reuses TT information from depth 1, while null-window move ordering now starts reusing TT information from depth 2. That keeps the node-count benefit from the TT shortcut while avoiding extra per-move overhead in the shallow NWS path, where NPS was more sensitive.

## Why
The task for this branch was to improve move ordering enough to reduce visited nodes without spending too much additional time on ordering itself. Reusing decisive TT bounds is a cheap way to skip some ordering probes, but applying it everywhere made shallow searches look too expensive from an NPS perspective. Splitting the threshold by search type preserves the main node reduction while improving the balance between ordering cost and throughput.

## Implementation details
- `get_move_ordering_tt_value` checks TT bounds for the child hash and accepts three cases: exact value, upper bound below `alpha`, or lower bound above `beta`.
- both `move_evaluate` and `move_evaluate_nws` use that TT-derived value as the ordering score and add the existing TT bonus when a decisive bound is available.
- `MOVE_ORDERING_TT_REUSE_MIN_DEPTH` and `MOVE_ORDERING_NWS_TT_REUSE_MIN_DEPTH` control when TT reuse is enabled for the normal and NWS ordering paths.
- the final tuning keeps TT reuse enabled for normal move ordering at depth 1, but delays it for NWS until depth 2 to reduce shallow-search overhead.

This PR was written using [Vibe Kanban](https://vibekanban.com)