### PR TITLE
Reduce shallow move ordering cost and refresh midgame bench script (Vibe Kanban)

### DIFF
--- a/bin/midtest.py
+++ b/bin/midtest.py
@@ -67,10 +67,14 @@ egaroucid = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
 line = strip_newlines(egaroucid.stdout.readline().decode())
 print('#   ' + line)
-for i in range(32):
+i = 0
+while True:
     line = strip_newlines(egaroucid.stdout.readline().decode())
-    line = '#' + fill0(i, 2) + ' ' + line
-    print(line)
-line = strip_newlines(egaroucid.stdout.readline().decode())
-print(line)
+    if line == '':
+        break
+    if line.startswith('total '):
+        print(line)
+        break
+    print('#' + fill0(i, 2) + ' ' + line)
+    i += 1
 egaroucid.kill()

--- a/bin/midtest.py
+++ b/bin/midtest.py
@@ -1,6 +1,7 @@
+import os
 import subprocess
 import sys
-import os
+
 
 def fill0(n, r):
     n = str(n)
@@ -9,42 +10,67 @@ def fill0(n, r):
         n = '0' + n
     return n
 
-exe = 'Egaroucid_for_Console.exe'
-# exe = 'Egaroucid_for_Console_20250717_before.exe'
-# exe = 'versions/Egaroucid_for_Console_7_5_1_Windows_SIMD/Egaroucid_for_Console_7_5_1_SIMD.exe'
-# exe = 'versions/Egaroucid_for_Console_7_6_0_Windows_SIMD/Egaroucid_for_Console_7_6_0_SIMD.exe'
-
-
-script_dir = os.path.dirname(os.path.abspath(__file__))
-if not os.path.isabs(exe):
-    exe = os.path.join(script_dir, exe)
-
-cmd_version = exe + ' -v'
-# print(cmd_version)
-version = subprocess.run((cmd_version).split(), stdin=subprocess.PIPE, stdout=subprocess.PIPE).stdout.decode()
 
 def strip_newlines(s):
     while s.endswith('\n') or s.endswith('\r'):
         s = s[:-1]
     return s
 
+
+level = 23
+n_threads = 32
+hash_level = 25
+exe = 'Egaroucid_for_Console.exe'
+problem_file = 'problem/midgame_test.txt'
+
+try:
+    if len(sys.argv) >= 2:
+        level = int(sys.argv[1])
+    if len(sys.argv) >= 3:
+        n_threads = int(sys.argv[2])
+    if len(sys.argv) >= 4:
+        hash_level = int(sys.argv[3])
+    if len(sys.argv) >= 5:
+        exe = sys.argv[4]
+    if len(sys.argv) >= 6:
+        problem_file = sys.argv[5]
+except Exception:
+    print('usage: python midtest.py [level=23] [n_threads=32] [hash_level=25] [exe=Egaroucid_for_Console.exe] [problem=problem/midgame_test.txt]')
+    exit()
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+if not os.path.isabs(exe):
+    exe = os.path.join(script_dir, exe)
+if not os.path.isabs(problem_file):
+    problem_file = os.path.join(script_dir, problem_file)
+
+cmd_version = [exe, '-v']
+version = subprocess.run(cmd_version, stdin=subprocess.PIPE, stdout=subprocess.PIPE).stdout.decode()
 version = strip_newlines(version)
 print(version)
 
-cmd = exe + ' -l 23 -nobook -thread 32 -solve ' + os.path.join(script_dir, 'problem/midgame_test.txt')
+cmd = [
+    exe,
+    '-l',
+    str(level),
+    '-nobook',
+    '-thread',
+    str(n_threads),
+    '-hash',
+    str(hash_level),
+    '-solve',
+    problem_file,
+]
 
-print(cmd.replace(script_dir, 'script_dir'))
-egaroucid = subprocess.Popen((cmd).split(), stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+print(' '.join(cmd).replace(script_dir, 'script_dir'))
+egaroucid = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
-res = ''
-line = egaroucid.stdout.readline().decode().replace('\n', '').replace('\r', '')
+line = strip_newlines(egaroucid.stdout.readline().decode())
 print('#   ' + line)
 for i in range(32):
-    line = egaroucid.stdout.readline().decode().replace('\n', '').replace('\r', '')
-    policy = line.split()[3][:-1]
+    line = strip_newlines(egaroucid.stdout.readline().decode())
     line = '#' + fill0(i, 2) + ' ' + line
     print(line)
-    res += line + '\n'
-line = egaroucid.stdout.readline().decode().replace('\n', '').replace('\r', '')
+line = strip_newlines(egaroucid.stdout.readline().decode())
 print(line)
 egaroucid.kill()

--- a/src/engine/move_ordering.hpp
+++ b/src/engine/move_ordering.hpp
@@ -254,7 +254,9 @@ inline void move_evaluate(Search *search, Flip_value *flip_value, int alpha, int
     search->move(&flip_value->flip);
         flip_value->n_legal = search->board.get_legal();
         flip_value->value += (MO_OFFSET_L_PM - get_weighted_n_moves(flip_value->n_legal)) * W_MOBILITY;
-        flip_value->value += (MO_OFFSET_L_PM - get_potential_mobility(search->board.opponent, ~(search->board.player | search->board.opponent))) * W_POTENTIAL_MOBILITY;
+        if (depth >= 1) {
+            flip_value->value += (MO_OFFSET_L_PM - get_potential_mobility(search->board.opponent, ~(search->board.player | search->board.opponent))) * W_POTENTIAL_MOBILITY;
+        }
         int child_value = SCORE_UNDEFINED;
         const bool has_tt_value = depth >= MOVE_ORDERING_TT_REUSE_MIN_DEPTH && get_move_ordering_tt_value(search, search->board.hash(), depth, alpha, beta, &child_value);
         switch (depth) {


### PR DESCRIPTION
## Summary
- update bin/midtest.py so the midgame benchmark can be run directly with python midtest.py 25 1 from bin
- allow the benchmark script to accept level, thread count, hash level, executable path, and problem path via CLI arguments
- resolve executable and problem paths relative to the script, and keep reading solver output until the total aggregate line is reached
- reduce regular move ordering cost by skipping the potential mobility term in the shallowest ordering re-searches while keeping it for deeper positions

## Why
The task for this branch was to improve move ordering while keeping the ordering cost under control, especially away from the root. The benchmark flow was also updated so the branch could be measured consistently from bin with both node count and NPS checked carefully.

## Implementation Details
- midtest.py now builds the solver command from explicit arguments instead of hardcoded values, and prints the final aggregate total line needed for benchmarking.
- The script also resolves relative paths from the bin directory, which matches the intended test workflow for this task.
- In move_ordering.hpp, the regular midgame move ordering path still evaluates mobility, but only adds potential mobility when the ordering depth is at least 1. This trims per-move work in the shallowest ordering probes without changing the deeper ordering behavior near the root.
- The change was validated against the branch benchmarks using midtest.py 25 1 and ffotest.py 40 49 1, comparing both visited nodes and NPS.

This PR was written using [Vibe Kanban](https://vibekanban.com)