### PR TITLE
Refine move ordering heuristics for continuation history and root search (Vibe Kanban)

### DIFF
--- a/src/engine/clogsearch.hpp
+++ b/src/engine/clogsearch.hpp
@@ -136,7 +136,7 @@ int clog_search(Search *search, int depth, bool *searching) {
     }
     uint_fast8_t moves[N_TRANSPOSITION_MOVES] = {MOVE_UNDEFINED, MOVE_UNDEFINED};
     transposition_table.get_moves_any_level(&search->board, search->board.hash(), moves);
-    move_list_evaluate(search, move_list, moves, depth, -SCORE_MAX, SCORE_MAX, searching);
+    move_list_evaluate(search, move_list, moves, depth, -SCORE_MAX, SCORE_MAX, false, searching);
     int g;
     bool uncertain_value_found = false;
     int beta = HW2 - 2 * pop_count_ull(calc_stability(search->board.opponent, search->board.player));

--- a/src/engine/human_like_ai.hpp
+++ b/src/engine/human_like_ai.hpp
@@ -69,7 +69,7 @@ int nega_alpha_human_like(Search *search, int alpha, int beta, int depth, bool s
         ++idx;
     }
     uint_fast8_t moves[N_TRANSPOSITION_MOVES] = {MOVE_UNDEFINED, MOVE_UNDEFINED};
-    move_list_evaluate(search, move_list, moves, depth, alpha, beta, searching);
+    move_list_evaluate(search, move_list, moves, depth, alpha, beta, false, searching);
     if (beta <= alpha) {
         return alpha;
     }
@@ -114,7 +114,7 @@ Search_result nega_alpha_human_like_root(Search *search, int alpha, int beta, in
         ++idx;
     }
     uint_fast8_t moves[N_TRANSPOSITION_MOVES] = {MOVE_UNDEFINED, MOVE_UNDEFINED};
-    move_list_evaluate(search, move_list, moves, depth, alpha, beta, searching);
+    move_list_evaluate(search, move_list, moves, depth, alpha, beta, false, searching);
     int g;
     res.value = -SCORE_INF;
     res.policy = MOVE_NOMOVE;

--- a/src/engine/midsearch.hpp
+++ b/src/engine/midsearch.hpp
@@ -270,7 +270,7 @@ int nega_scout(Search *search, int alpha, int beta, const int depth, const bool 
         move_list[tt_moves_idx0].value = -INF;
     }
     if (alpha < beta) {
-        move_list_evaluate(search, move_list, canput, moves, depth, alpha, beta, searching);
+        move_list_evaluate(search, move_list, canput, moves, depth, alpha, beta, is_end_search, searching);
 #if USE_YBWC_NEGASCOUT
         if (search->use_multi_thread && ((!is_end_search && depth - 1 >= YBWC_MID_SPLIT_MIN_DEPTH) || (is_end_search && depth - 1 >= YBWC_END_SPLIT_MIN_DEPTH))) {
             move_list_sort(move_list, canput);
@@ -566,7 +566,7 @@ std::pair<int, int> first_nega_scout_legal(Search *search, int alpha, int beta, 
         }
         uint_fast8_t moves[N_TRANSPOSITION_MOVES] = {MOVE_UNDEFINED, MOVE_UNDEFINED};
         transposition_table.get_moves_any_level(&search->board, hash_code, moves);
-        move_list_evaluate(search, move_list, canput, moves, depth, alpha, beta, searching);
+        move_list_evaluate(search, move_list, canput, moves, depth, alpha, beta, is_end_search, searching);
 #if USE_YBWC_NEGASCOUT
         if (
             search->use_multi_thread && 
@@ -704,7 +704,7 @@ Analyze_result first_nega_scout_analyze(Search *search, int alpha, int beta, con
         }
         uint_fast8_t moves[N_TRANSPOSITION_MOVES] = {MOVE_UNDEFINED, MOVE_UNDEFINED};
         transposition_table.get_moves_any_level(&search->board, hash_code, moves);
-        move_list_evaluate(search, move_list, canput, moves, depth, alpha, beta, searching);
+        move_list_evaluate(search, move_list, canput, moves, depth, alpha, beta, is_end_search, searching);
 #if USE_YBWC_NEGASCOUT_ANALYZE
         if (search->use_multi_thread && depth - 1 >= YBWC_MID_SPLIT_MIN_DEPTH) {
             move_list_sort(move_list);

--- a/src/engine/midsearch_nws.hpp
+++ b/src/engine/midsearch_nws.hpp
@@ -278,7 +278,7 @@ int nega_alpha_ordering_nws_simple(Search *search, int alpha, const int depth, c
     //     move_list[tt_moves_idx1].value = -INF;
     // }
     if (v <= alpha) {
-        move_list_evaluate_nws(search, move_list, canput, moves, depth, alpha, searching);
+        move_list_evaluate_nws(search, move_list, canput, moves, depth, alpha, false, searching);
 #if USE_MID_ETC && MID_ETC_DEPTH_NWS <= MID_SIMPLE_ORDERING_DEPTH
         for (int move_idx = 0; move_idx < canput - n_etc_done && *searching; ++move_idx) {
 #else
@@ -416,7 +416,7 @@ int nega_alpha_ordering_nws(Search *search, int alpha, const int depth, const bo
         move_list[tt_moves_idx0].value = -INF;
     }
     if (v <= alpha) {
-        move_list_evaluate_nws(search, move_list, canput, moves, depth, alpha, searchings.back());
+        move_list_evaluate_nws(search, move_list, canput, moves, depth, alpha, false, searchings.back());
 #if USE_YBWC_NWS
         if (
             search->use_multi_thread && 

--- a/src/engine/move_ordering.hpp
+++ b/src/engine/move_ordering.hpp
@@ -108,6 +108,8 @@ constexpr int MOVE_ORDERING_VALUE_OFFSET_ALPHA = 12;
 constexpr int MOVE_ORDERING_VALUE_OFFSET_BETA = 8;
 constexpr int MOVE_ORDERING_NWS_VALUE_OFFSET_ALPHA = 16;
 constexpr int MOVE_ORDERING_NWS_VALUE_OFFSET_BETA = 6;
+constexpr int MOVE_ORDERING_ROOT_PLY_EXTENDED = 0;
+constexpr int MOVE_ORDERING_ROOT_BRANCH_LIMIT = 10;
 
 constexpr int MOVE_ORDERING_MPC_LEVEL = MPC_74_LEVEL;
 constexpr int MOVE_ORDERING_TT_REUSE_MIN_DEPTH = 1;
@@ -477,13 +479,16 @@ inline bool move_list_tt_check(Search *search, std::vector<Flip_value> &move_lis
     @param beta                 beta value
     @param searching            flag for terminating this search
 */
-inline bool move_list_evaluate(Search *search, std::vector<Flip_value> &move_list, uint_fast8_t moves[], int depth, int alpha, int beta, bool *searching) {
+inline bool move_list_evaluate(Search *search, std::vector<Flip_value> &move_list, uint_fast8_t moves[], int depth, int alpha, int beta, bool is_end_search, bool *searching) {
     if (move_list.size() == 1) {
         return false;
     }
     int eval_alpha = -std::min(SCORE_MAX, beta + MOVE_ORDERING_VALUE_OFFSET_BETA);
     int eval_beta = -std::max(-SCORE_MAX, alpha - MOVE_ORDERING_VALUE_OFFSET_ALPHA);
     int eval_depth = depth >> 3;
+    if (!is_end_search && search->get_ply() <= MOVE_ORDERING_ROOT_PLY_EXTENDED && move_list.size() <= MOVE_ORDERING_ROOT_BRANCH_LIMIT) {
+        eval_depth = std::max(eval_depth, depth >> 2);
+    }
     if (depth >= 25 && search->mpc_level < MPC_100_LEVEL) {
         eval_depth = ((depth / 3) & 0b11111110) + (depth & 1); // depth / 3 + parity
     }
@@ -516,13 +521,16 @@ inline bool move_list_evaluate(Search *search, std::vector<Flip_value> &move_lis
     @param beta                 beta value
     @param searching            flag for terminating this search
 */
-inline bool move_list_evaluate(Search *search, Flip_value move_list[], int canput, uint_fast8_t moves[], int depth, int alpha, int beta, bool *searching) {
+inline bool move_list_evaluate(Search *search, Flip_value move_list[], int canput, uint_fast8_t moves[], int depth, int alpha, int beta, bool is_end_search, bool *searching) {
     if (canput == 1) {
         return false;
     }
     int eval_alpha = -std::min(SCORE_MAX, beta + MOVE_ORDERING_VALUE_OFFSET_BETA);
     int eval_beta = -std::max(-SCORE_MAX, alpha - MOVE_ORDERING_VALUE_OFFSET_ALPHA);
     int eval_depth = depth >> 3;
+    if (!is_end_search && search->get_ply() <= MOVE_ORDERING_ROOT_PLY_EXTENDED && canput <= MOVE_ORDERING_ROOT_BRANCH_LIMIT) {
+        eval_depth = std::max(eval_depth, depth >> 2);
+    }
     if (depth >= 25 && search->mpc_level < MPC_100_LEVEL) {
         eval_depth = ((depth / 3) & 0b11111110) + (depth & 1); // depth / 3 + parity
     }
@@ -554,7 +562,7 @@ inline bool move_list_evaluate(Search *search, Flip_value move_list[], int canpu
     @param alpha                alpha value (beta = alpha + 1)
     @param searching            flag for terminating this search
 */
-inline bool move_list_evaluate_nws(Search *search, std::vector<Flip_value> &move_list, uint_fast8_t moves[], int depth, int alpha, bool *searching) {
+inline bool move_list_evaluate_nws(Search *search, std::vector<Flip_value> &move_list, uint_fast8_t moves[], int depth, int alpha, bool is_end_search, bool *searching) {
     if (move_list.size() <= 1) {
         return false;
     }
@@ -585,7 +593,7 @@ inline bool move_list_evaluate_nws(Search *search, std::vector<Flip_value> &move
     @param alpha                alpha value (beta = alpha + 1)
     @param searching            flag for terminating this search
 */
-inline bool move_list_evaluate_nws(Search *search, Flip_value move_list[], int canput, uint_fast8_t moves[], int depth, int alpha, bool *searching) {
+inline bool move_list_evaluate_nws(Search *search, Flip_value move_list[], int canput, uint_fast8_t moves[], int depth, int alpha, bool is_end_search, bool *searching) {
     if (canput <= 1) {
         return false;
     }

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -122,6 +122,8 @@ constexpr int MAX_PLY = 65;
 */
 constexpr int HISTORY_MAX = 16384;  // Maximum history value
 constexpr int HISTORY_SCALE = 16;   // History aging factor
+constexpr int HISTORY_ORDERING_SHIFT = 5;
+constexpr int HISTORY_ORDERING_MAX_BONUS = 128;
 #endif
 
 
@@ -255,7 +257,7 @@ class Search {
         
         // History heuristic (move ordering based on past performance)
         // Use smaller history table to avoid stack overflow
-        int history[HW2];  // Simplified history for move positions only
+        int history[HW2][HW2];  // Continuation history indexed by previous move and current move
         
         // Counter move heuristic (response to previous move)
         int counter_moves[HW2];  // counter_moves[prev_move] = best_response
@@ -518,7 +520,9 @@ class Search {
         */
         inline void clear_history() {
             for (int i = 0; i < HW2; ++i) {
-                history[i] = 0;
+                for (int j = 0; j < HW2; ++j) {
+                    history[i][j] = 0;
+                }
             }
         }
 
@@ -544,14 +548,13 @@ class Search {
             @brief Update history heuristic
         */
         inline void update_history(int from_pos, int to_pos, int depth) {
-            // Simplified: use only destination position for history
-            if (to_pos < 0 || to_pos >= HW2) {
+            if (from_pos < 0 || from_pos >= HW2 || to_pos < 0 || to_pos >= HW2) {
                 return;
             }
             int bonus = depth * depth;
-            history[to_pos] += bonus;
+            history[from_pos][to_pos] += bonus;
             // Prevent overflow
-            if (history[to_pos] > HISTORY_MAX) {
+            if (history[from_pos][to_pos] > HISTORY_MAX) {
                 age_history();
             }
         }
@@ -561,7 +564,9 @@ class Search {
         */
         inline void age_history() {
             for (int i = 0; i < HW2; ++i) {
-                history[i] /= HISTORY_SCALE;
+                for (int j = 0; j < HW2; ++j) {
+                    history[i][j] /= HISTORY_SCALE;
+                }
             }
         }
 
@@ -578,9 +583,8 @@ class Search {
             @brief Get history bonus for move ordering
         */
         inline int get_history_bonus(int from_pos, int to_pos) const {
-            // Simplified: use only destination position
-            if (to_pos < 0 || to_pos >= HW2) return 0;
-            return history[to_pos] / (HISTORY_MAX + 1);
+            if (from_pos < 0 || from_pos >= HW2 || to_pos < 0 || to_pos >= HW2) return 0;
+            return std::min(HISTORY_ORDERING_MAX_BONUS, history[from_pos][to_pos] >> HISTORY_ORDERING_SHIFT);
         }
 
         /*

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -237,7 +237,7 @@ struct Analyze_result {
 class Search {
     public:
         Board board;
-        //int_fast8_t strt_n_discs;
+        int_fast8_t root_n_discs;
         int_fast8_t n_discs;
         uint_fast8_t parity;
         uint_fast8_t mpc_level;
@@ -271,7 +271,7 @@ class Search {
         Search() {};
 
         Search(const Board *board_, uint_fast8_t mpc_level_, bool use_multi_thread_, bool is_presearch_)
-            : board(board_->copy()), n_discs(board_->n_discs()), mpc_level(mpc_level_), use_multi_thread(use_multi_thread_), n_nodes(0), is_presearch(is_presearch_), thread_id(THREAD_ID_NONE) {
+            : board(board_->copy()), root_n_discs(board_->n_discs()), n_discs(board_->n_discs()), mpc_level(mpc_level_), use_multi_thread(use_multi_thread_), n_nodes(0), is_presearch(is_presearch_), thread_id(THREAD_ID_NONE) {
             uint64_t empty = ~(board.player | board.opponent);
             parity = 1 & pop_count_ull(empty & 0x000000000F0F0F0FULL);
             parity |= (1 & pop_count_ull(empty & 0x00000000F0F0F0F0ULL)) << 1;
@@ -280,11 +280,14 @@ class Search {
             calc_eval_features(&board, &eval);
 #if USE_KILLER_MOVE_MO
             clear_killers();
+            clear_history();
+            clear_counter_moves();
+            clear_move_history();
 #endif
         }
 
         Search(uint64_t board_player, uint64_t board_opponent, uint_fast8_t mpc_level_, bool use_multi_thread_, bool is_presearch_)
-            : board(Board{board_player, board_opponent}), n_discs(pop_count_ull(board_player | board_opponent)), mpc_level(mpc_level_), use_multi_thread(use_multi_thread_), n_nodes(0), is_presearch(is_presearch_), thread_id(THREAD_ID_NONE) {
+            : board(Board{board_player, board_opponent}), root_n_discs(pop_count_ull(board_player | board_opponent)), n_discs(pop_count_ull(board_player | board_opponent)), mpc_level(mpc_level_), use_multi_thread(use_multi_thread_), n_nodes(0), is_presearch(is_presearch_), thread_id(THREAD_ID_NONE) {
             uint64_t empty = ~(board.player | board.opponent);
             parity = 1 & pop_count_ull(empty & 0x000000000F0F0F0FULL);
             parity |= (1 & pop_count_ull(empty & 0x00000000F0F0F0F0ULL)) << 1;
@@ -300,7 +303,7 @@ class Search {
         }
 
         Search(uint64_t board_player, uint64_t board_opponent, int_fast8_t n_discs_, uint_fast8_t parity_, uint_fast8_t mpc_level_, bool use_multi_thread_, bool is_presearch_, thread_id_t thread_id_)
-            : board(Board(board_player, board_opponent)), n_discs(n_discs_), parity(parity_), mpc_level(mpc_level_), use_multi_thread(use_multi_thread_), n_nodes(0), is_presearch(is_presearch_), thread_id(thread_id_) {
+            : board(Board(board_player, board_opponent)), root_n_discs(n_discs_), n_discs(n_discs_), parity(parity_), mpc_level(mpc_level_), use_multi_thread(use_multi_thread_), n_nodes(0), is_presearch(is_presearch_), thread_id(thread_id_) {
             calc_eval_features(&board, &eval);
 #if USE_KILLER_MOVE_MO
             clear_killers();
@@ -316,7 +319,7 @@ class Search {
             @param init_board           a board to set
         */
         Search(const Board *board_)
-            : board(board_->copy()), n_discs(board_->n_discs()), thread_id(THREAD_ID_NONE) {
+            : board(board_->copy()), root_n_discs(board_->n_discs()), n_discs(board_->n_discs()), thread_id(THREAD_ID_NONE) {
             uint64_t empty = ~(board.player | board.opponent);
             parity = 1 & pop_count_ull(empty & 0x000000000F0F0F0FULL);
             parity |= (1 & pop_count_ull(empty & 0x00000000F0F0F0F0ULL)) << 1;
@@ -325,6 +328,9 @@ class Search {
             calc_eval_features(&board, &eval);
 #if USE_KILLER_MOVE_MO
             clear_killers();
+            clear_history();
+            clear_counter_moves();
+            clear_move_history();
 #endif
         }
         
@@ -474,6 +480,13 @@ class Search {
             //return std::min(N_PHASES - 1, (n_discs - 4) / PHASE_N_DISCS);
         }
 
+        /*
+            @brief Get current ply (search depth from root)
+        */
+        inline int get_ply() const {
+            return n_discs - root_n_discs;
+        }
+
 #if USE_KILLER_MOVE_MO
         /*
             @brief Clear killer moves table
@@ -483,13 +496,6 @@ class Search {
                 killer1[i] = -1;
                 killer2[i] = -1;
             }
-        }
-
-        /*
-            @brief Get current ply (search depth from root)
-        */
-        inline int get_ply() const {
-            return n_discs - 4;
         }
 
         /*


### PR DESCRIPTION
## What changed
- Switched the move ordering history heuristic in `src/engine/search.hpp` from a single-dimension per-move table to a continuation-history style table keyed by previous move and current move.
- Added explicit scaling constants for history-based move ordering bonuses and fixed the history bonus calculation so it can contribute meaningful ordering scores when the killer/history path is enabled.
- Added root-relative ply tracking in `Search` and threaded end-search awareness through move-ordering call sites in `midsearch`, `midsearch_nws`, `clogsearch`, and `human_like_ai`.
- Updated `src/engine/move_ordering.hpp` so non-end-search positions near the root can use a slightly deeper ordering search without applying the same extra cost to end-search ordering.
- Fixed constructor initialization for search-side move-ordering state so killer/history/counter-move structures are initialized consistently.

## Why
This branch was created to improve move ordering and reduce visited node count, while keeping ordering overhead under control. The task context explicitly allowed spending somewhat more work near the root, but not everywhere. The changes in this PR are aimed at making the ordering heuristics more informative and at concentrating extra ordering cost only where it is most likely to pay off.

## Important implementation details
- `Search` now tracks `root_n_discs`, and `get_ply()` returns ply-from-root rather than a board-global disc offset.
- The history heuristic now stores continuation information as `history[prev_move][move]`, which is a better fit for move ordering than the previous flattened table.
- Root-depth move-ordering expansion is gated by both search context and branching limits so the extra work stays localized.
- End-search call sites now pass explicit search-mode information into move ordering, allowing midgame-specific ordering depth adjustments without forcing the same behavior in end-search paths.
- Supporting call sites were updated to match the new move-ordering function signatures.

## Context
The branch was evaluated with the requested single-thread benchmark flow in `bin`, comparing node count and NPS with:
- `python midtest.py 25 1`
- `python ffotest.py 40 49 1`

This PR was written using [Vibe Kanban](https://vibekanban.com)