### PR TITLE
Refine sparse-root move ordering heuristics (Vibe Kanban)

### DIFF
--- a/src/engine/move_ordering.hpp
+++ b/src/engine/move_ordering.hpp
@@ -108,8 +108,9 @@ constexpr int MOVE_ORDERING_VALUE_OFFSET_ALPHA = 12;
 constexpr int MOVE_ORDERING_VALUE_OFFSET_BETA = 8;
 constexpr int MOVE_ORDERING_NWS_VALUE_OFFSET_ALPHA = 16;
 constexpr int MOVE_ORDERING_NWS_VALUE_OFFSET_BETA = 6;
-constexpr int MOVE_ORDERING_ROOT_PLY_EXTENDED = 0;
+constexpr int MOVE_ORDERING_ROOT_PLY_EXTENDED = 2;
 constexpr int MOVE_ORDERING_ROOT_BRANCH_LIMIT = 10;
+constexpr int MOVE_ORDERING_ROOT_MAX_N_DISCS = 28;
 
 constexpr int MOVE_ORDERING_MPC_LEVEL = MPC_74_LEVEL;
 constexpr int MOVE_ORDERING_TT_REUSE_MIN_DEPTH = 1;
@@ -120,6 +121,13 @@ int nega_scout(Search *search, int alpha, int beta, const int depth, const bool 
 inline bool transposition_table_get_value(Search *search, uint32_t hash, int *l, int *u);
 inline int mid_evaluate_diff(Search *search);
 inline int mid_evaluate_move_ordering_end(Search *search);
+
+inline bool use_root_move_ordering_extension(const Search *search, int branch_count, bool is_end_search) {
+    return !is_end_search &&
+        search->root_n_discs <= MOVE_ORDERING_ROOT_MAX_N_DISCS &&
+        search->get_ply() <= MOVE_ORDERING_ROOT_PLY_EXTENDED &&
+        branch_count <= MOVE_ORDERING_ROOT_BRANCH_LIMIT;
+}
 
 inline bool get_move_ordering_tt_value(Search *search, uint32_t hash, int depth, int alpha, int beta, int *value) {
     int lower = -SCORE_INF;
@@ -486,7 +494,7 @@ inline bool move_list_evaluate(Search *search, std::vector<Flip_value> &move_lis
     int eval_alpha = -std::min(SCORE_MAX, beta + MOVE_ORDERING_VALUE_OFFSET_BETA);
     int eval_beta = -std::max(-SCORE_MAX, alpha - MOVE_ORDERING_VALUE_OFFSET_ALPHA);
     int eval_depth = depth >> 3;
-    if (!is_end_search && search->get_ply() <= MOVE_ORDERING_ROOT_PLY_EXTENDED && move_list.size() <= MOVE_ORDERING_ROOT_BRANCH_LIMIT) {
+    if (use_root_move_ordering_extension(search, static_cast<int>(move_list.size()), is_end_search)) {
         eval_depth = std::max(eval_depth, depth >> 2);
     }
     if (depth >= 25 && search->mpc_level < MPC_100_LEVEL) {
@@ -528,7 +536,7 @@ inline bool move_list_evaluate(Search *search, Flip_value move_list[], int canpu
     int eval_alpha = -std::min(SCORE_MAX, beta + MOVE_ORDERING_VALUE_OFFSET_BETA);
     int eval_beta = -std::max(-SCORE_MAX, alpha - MOVE_ORDERING_VALUE_OFFSET_ALPHA);
     int eval_depth = depth >> 3;
-    if (!is_end_search && search->get_ply() <= MOVE_ORDERING_ROOT_PLY_EXTENDED && canput <= MOVE_ORDERING_ROOT_BRANCH_LIMIT) {
+    if (use_root_move_ordering_extension(search, canput, is_end_search)) {
         eval_depth = std::max(eval_depth, depth >> 2);
     }
     if (depth >= 25 && search->mpc_level < MPC_100_LEVEL) {
@@ -569,6 +577,9 @@ inline bool move_list_evaluate_nws(Search *search, std::vector<Flip_value> &move
     const int eval_alpha = -std::min(SCORE_MAX, alpha + MOVE_ORDERING_NWS_VALUE_OFFSET_BETA);
     const int eval_beta = -std::max(-SCORE_MAX, alpha - MOVE_ORDERING_NWS_VALUE_OFFSET_ALPHA);
     int eval_depth = depth >> 4;
+    if (use_root_move_ordering_extension(search, static_cast<int>(move_list.size()), is_end_search)) {
+        eval_depth = std::max(eval_depth, depth >> 3);
+    }
     for (Flip_value &flip_value: move_list) {
         if (flip_value.flip.flip) {
             if (flip_value.flip.pos == moves[0]) {
@@ -600,6 +611,9 @@ inline bool move_list_evaluate_nws(Search *search, Flip_value move_list[], int c
     const int eval_alpha = -std::min(SCORE_MAX, alpha + MOVE_ORDERING_NWS_VALUE_OFFSET_BETA);
     const int eval_beta = -std::max(-SCORE_MAX, alpha - MOVE_ORDERING_NWS_VALUE_OFFSET_ALPHA);
     int eval_depth = depth >> 4;
+    if (use_root_move_ordering_extension(search, canput, is_end_search)) {
+        eval_depth = std::max(eval_depth, depth >> 3);
+    }
     for (int i = 0; i < canput; ++i) {
         if (move_list[i].flip.flip) {
             if (move_list[i].flip.pos == moves[0]) {

--- a/src/engine/move_ordering.hpp
+++ b/src/engine/move_ordering.hpp
@@ -578,7 +578,7 @@ inline bool move_list_evaluate_nws(Search *search, std::vector<Flip_value> &move
     const int eval_beta = -std::max(-SCORE_MAX, alpha - MOVE_ORDERING_NWS_VALUE_OFFSET_ALPHA);
     int eval_depth = depth >> 4;
     if (use_root_move_ordering_extension(search, static_cast<int>(move_list.size()), is_end_search)) {
-        eval_depth = std::max(eval_depth, depth >> 3);
+        eval_depth = std::max(eval_depth, depth >> 2);
     }
     for (Flip_value &flip_value: move_list) {
         if (flip_value.flip.flip) {
@@ -612,7 +612,7 @@ inline bool move_list_evaluate_nws(Search *search, Flip_value move_list[], int c
     const int eval_beta = -std::max(-SCORE_MAX, alpha - MOVE_ORDERING_NWS_VALUE_OFFSET_ALPHA);
     int eval_depth = depth >> 4;
     if (use_root_move_ordering_extension(search, canput, is_end_search)) {
-        eval_depth = std::max(eval_depth, depth >> 3);
+        eval_depth = std::max(eval_depth, depth >> 2);
     }
     for (int i = 0; i < canput; ++i) {
         if (move_list[i].flip.flip) {


### PR DESCRIPTION
## Summary
- make move-ordering history state root-aware by tracking the root disc count and using root-relative ply in `Search`
- fix and rewire the history heuristic so continuation history bonuses are actually usable during move ordering
- add root-sensitive move-ordering depth handling in `move_ordering.hpp`, and apply it only to sparse midgame roots by checking branch count, root ply, and root disc count
- propagate the new move-ordering context through the midsearch, null-window search, clog search, and human-like AI call sites
- deepen sparse-root NWS move-ordering evaluation further after benchmarking showed additional node-count savings without regressing the FFO benchmark set

## Why
This branch comes from a move-ordering optimization task with a specific goal: reduce visited nodes while avoiding large extra ordering cost. The constraint was that extra work is acceptable near the root, but should not spill broadly into deeper nodes or endgame-style positions.

## Implementation Details
- `Search` now stores the root disc count and exposes root-relative ply so move-ordering logic can distinguish true root-adjacent nodes from deeper descendants.
- The history heuristic was corrected from an effectively inactive setup into continuation history indexed by previous move and current move, and the ordering bonus scaling was fixed so the heuristic contributes non-zero scores.
- Root move-ordering extensions were localized in `move_ordering.hpp` behind a helper that checks:
  - whether the search is not an end-search
  - whether the position is still a sparse root (`root_n_discs <= 28`)
  - whether the node is within the configured root ply window
  - whether the branching factor is small enough to justify extra ordering work
- Full-window move ordering and NWS move ordering now use different root-depth boosts, with the NWS path strengthened further for sparse roots after measurement.
- The additional `is_end_search` context was threaded through the relevant move-ordering call sites so the root-depth tuning does not leak into endgame-oriented search paths.

## Benchmark Notes
The changes were evaluated in `bin` with one thread using:
- `python midtest.py 25 1`
- `python ffotest.py 40 49 1`

The final sparse-root NWS tuning reduced `midtest` node counts from the earlier baseline while keeping `ffotest 40-49` node counts unchanged, matching the task requirement to improve ordering without broadly increasing search cost.

This PR was written using [Vibe Kanban](https://vibekanban.com)