### PR TITLE
YBWC task cancellation and split throttling (Vibe Kanban)

### DIFF
--- a/src/engine/ybwc.hpp
+++ b/src/engine/ybwc.hpp
@@ -28,7 +28,7 @@ constexpr int YBWC_END_SPLIT_MIN_DEPTH = 16;
 //constexpr int YBWC_END_SPLIT_MAX_DEPTH = 29;
 // constexpr int YBWC_N_ELDER_CHILD = 1;
 constexpr int YBWC_N_YOUNGER_CHILD = 1;
-// constexpr int YBWC_MAX_RUNNING_COUNT = 5;
+constexpr int YBWC_MAX_RUNNING_COUNT = 8;
 constexpr int YBWC_NOT_PUSHED = -124;
 constexpr int YBWC_PUSHED = 124;
 
@@ -201,6 +201,7 @@ inline int ybwc_split_nws(Search *search, int parent_alpha, const int depth, uin
     #endif
     if (
             idle_ok &&                                  // There is an idle thread
+            running_count < YBWC_MAX_RUNNING_COUNT &&
             n_remaining_moves >= YBWC_N_YOUNGER_CHILD    // This node is not the (some) youngest brother
     ) {
         // int v;
@@ -503,6 +504,7 @@ void ybwc_search_young_brothers(Search *search, int *alpha, int *beta, int *v, i
                 }
                 if (*alpha < task_result.value) {
                     next_alpha = std::max(next_alpha, task_result.value);
+                    n_searching = false;
                     research_idxes.emplace_back(task_result.move_idx);
                 } else {
                     move_list[task_result.move_idx].flip.flip = 0;
@@ -602,6 +604,7 @@ void ybwc_search_young_brothers(Search *search, int *alpha, int *beta, int *v, i
                 }
                 if (*alpha < task_result.value) {
                     next_alpha = std::max(next_alpha, task_result.value);
+                    n_searching = false;
                     research_idxes.emplace_back(task_result.move_idx);
                 } else {
                     move_list[task_result.move_idx].flip.flip = 0;


### PR DESCRIPTION
This PR tunes the YBWC implementation in `src/engine/ybwc.hpp` to reduce wasted parallel search work in midgame search.

What changed
- Added a cap on the number of simultaneously running YBWC split tasks with `YBWC_MAX_RUNNING_COUNT = 8`.
- Updated `ybwc_split_nws` so new sibling tasks are only spawned while the current running task count is below that cap.
- In both `ybwc_search_young_brothers` overloads, when a parallel task returns a fail-high result (`task_result.value > alpha`), the parent now sets `n_searching = false` immediately before scheduling the full-window re-search.

Why these changes were made
- The task for this branch was to speed up YBWC and move ordering in `src/engine`, with the most urgent issue being that parallel midgame search was visiting far more nodes than the 1-thread search.
- In the previous YBWC behavior, too many sibling null-window tasks could be in flight at once, and when one of them raised alpha, other siblings could continue searching with an outdated window.
- That inflated the visited node count significantly in parallel midgame search, which was the main regression called out in the task context.

Important implementation details
- The split cap is enforced at task creation time inside `ybwc_split_nws`, so the change limits speculative sibling work without changing the overall search structure.
- The new `n_searching = false` on parallel fail-high mirrors the existing serial fail-high handling and makes sibling cancellation consistent regardless of whether the result came from the main thread or a worker task.
- The goal of these changes is not to reduce raw parallelism in general, but to cut off stale-window work early enough that node growth stays under control while preserving useful throughput.

This PR was written using [Vibe Kanban](https://vibekanban.com)