### PR TITLE
Fix/shortcut keys ime

### DIFF
--- a/docs/shortcut_key_ime_validation.md
+++ b/docs/shortcut_key_ime_validation.md
@@ -1,0 +1,145 @@
+# Windows Shortcut Key IME Validation
+
+## Scope
+
+This PR updates Windows shortcut matching so Egaroucid does not depend only on
+Siv3D `Input::name()` for shortcut identity. On Windows, shortcut matching now
+normalizes keyboard input through virtual-key codes, checks exact key
+combinations from one keyboard-state snapshot, and keeps the existing Siv3D
+string fallback for unmapped or non-Windows cases.
+
+The fix is intended to cover both default shortcuts and user-customized
+shortcuts. Custom shortcuts that can be mapped to Windows virtual-key codes use
+the same IME/layout-stable path as the defaults. Unknown custom names still use
+the original Siv3D fallback.
+
+## Modified Files
+
+- `src/gui/function/shortcut_key.hpp`
+  - Adds Windows virtual-key name normalization for shortcut capture and
+    matching.
+  - Handles common alphanumeric keys, function keys, numpad keys, navigation
+    keys, OEM punctuation keys, Windows keys, IME keys, media/browser keys, and
+    `0xNN` virtual-key names.
+  - Enforces exact non-modifier matching by scanning the current Windows
+    keyboard snapshot instead of checking only a short hard-coded key list.
+  - Enforces stricter Ctrl/Shift/Alt family matching, including left/right
+    modifier cases.
+  - Treats `down` as true only when the exact shortcut is active and an
+    expected key became newly pressed.
+  - Adds opt-in diagnostic logging controlled by environment variables:
+    `EGAROUCID_SHORTCUT_DIAG_LOG` and `EGAROUCID_SHORTCUT_DIAG_ONLY`.
+- `tools/shortcut_diag/run_shortcut_diag.ps1`
+  - Runs Egaroucid with the diagnostic environment variables enabled.
+  - Supports `Default`, `NegativeExtra`, and `CustomVkPositive` scenarios.
+  - Writes validation logs to `review_packages` by default so they can be
+    attached to review comments without being committed.
+- `docs/shortcut_key_ime_validation.md`
+  - This validation record.
+
+Local build-only changes in `src/gui/function/const/gui_common.hpp` are not part
+of this PR validation scope.
+
+## Validation Environment
+
+- OS: Windows
+- Build used for testing: `bin/Egaroucid.exe`
+- Build command used locally:
+  - `MSBuild.exe Egaroucid.sln /p:Configuration=Release /p:Platform=x64 /m`
+- Static check:
+  - `git diff --check`
+- Available input methods on this machine:
+  - Microsoft ENG input method
+  - Microsoft Chinese Pinyin input method
+
+Because this machine only has Microsoft ENG and Microsoft Chinese Pinyin
+available, additional validation should be performed by other developers with
+other IMEs and keyboard layouts, especially Japanese IME and any layout reported
+by users in the original issue.
+
+## Latest Test Results
+
+All listed tests passed with the current shortcut-key patch.
+
+| Scenario | Input method state | Result | Attachment log |
+| --- | --- | --- | --- |
+| Default shortcuts | ENG startup | 24/24 | `review_packages/shortcut_diag_custom_vk_patch_smoke_20260612_194934.log` |
+| Extra-key negative cases | ENG startup | 4/4 | `review_packages/shortcut_diag_negative_extra_keys_20260612_195044.log` |
+| Extra-key negative cases, committed script self-check | Current active input method | 4/4 | `review_packages/shortcut_diag_script_selfcheck_negative_20260612_200725.log` |
+| Custom shortcut VK cases | ENG startup | 2/2 | `review_packages/shortcut_diag_custom_vk_positive_20260612_195216.log` |
+| Default shortcuts | Chinese Pinyin startup | 24/24 | `review_packages/shortcut_diag_custom_vk_patch_chinese_all_20260612_195425.log` |
+| Default shortcuts | ENG startup, then switched to Chinese Pinyin before testing | 24/24 | `review_packages/shortcut_diag_custom_vk_patch_eng_start_then_chinese_all_20260612_195600.log` |
+
+Earlier contaminated manual runs, including the run where Alt was accidentally
+held during testing, are intentionally excluded from this validation record.
+
+## Covered Shortcut Cases
+
+The `Default` scenario validates all currently assigned default shortcuts:
+
+- `Space` -> `start_game`
+- `Ctrl+N` -> `new_game`
+- `A` -> `analyze`
+- `B` -> `ai_put_black`
+- `W` -> `ai_put_white`
+- `V` -> `show_disc_hint`
+- `U` -> `show_umigame_value`
+- `D` -> `show_graph_value`
+- `S` -> `show_graph_sum_of_loss`
+- `P` -> `show_laser_pointer`
+- `G` -> `put_1_move_by_ai`
+- `Right` -> `forward`
+- `Left` -> `backward`
+- `Backspace` -> `undo`
+- `Home` -> `go_to_first_position`
+- `End` -> `go_to_last_position`
+- `Shift+Home` -> `go_to_random_generated_position`
+- `Ctrl+L` -> `save_this_branch`
+- `Ctrl+R` -> `generate_random_board`
+- `Q` -> `stop_calculating`
+- `Ctrl+V` -> `input_from_clipboard`
+- `Ctrl+E` -> `edit_board`
+- `Ctrl+C` -> `output_transcript`
+- `Ctrl+S` -> `screen_shot`
+
+The `NegativeExtra` scenario validates that incomplete exact matching does not
+trigger shortcuts:
+
+- `Ctrl+Shift+N` does not trigger `new_game`
+- `A+F1` does not trigger `analyze`
+- `A+Num0` does not trigger `analyze`
+- Releasing `F1` while `A` remains held does not fire `analyze` as a new
+  `down` event
+
+The `CustomVkPositive` scenario temporarily writes a local
+`shortcut_key.json`, restores it afterward, and validates custom bindings:
+
+- `F1` -> `analyze`
+- `Num0` -> `ai_put_black`
+
+## Reproduction Commands
+
+Build Egaroucid first, then run from the repository root:
+
+```powershell
+.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario Default -Label eng_default
+.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario Default -Label chinese_default -PromptBeforeKeys
+.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario Default -Label eng_then_chinese -PromptBeforeKeys
+.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario NegativeExtra -Label negative_extra
+.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario CustomVkPositive -Label custom_vk
+```
+
+Use `-PromptBeforeKeys` when the tester needs to switch the active input method
+after Egaroucid starts and before automated key input begins.
+
+## Remaining Validation Needed
+
+Other developers should repeat the default, negative, and custom shortcut
+scenarios on input methods and keyboard layouts not available on this machine.
+In particular:
+
+- Japanese IME
+- Non-US keyboard layouts
+- Any IME/layout combination reported by users in the original issue
+- Additional customized shortcut names if a user report includes a specific
+  unsupported key

--- a/src/gui/function/shortcut_key.hpp
+++ b/src/gui/function/shortcut_key.hpp
@@ -11,6 +11,9 @@
 #pragma once
 #include <Siv3D.hpp>
 #include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
 #include <vector>
 #include <unordered_set>
 #include <unordered_map>
@@ -215,7 +218,7 @@ String generate_key_str(std::vector<String> keys) {
             res += U"->";
         } else if (keys[i] == U"Left") {
             res += U"<-";
-        } else if (keys[i] == U"0x5b") {
+        } else if (keys[i] == U"0x5b" || keys[i] == U"0x5c") {
             res += U"Windows";
         } else{
             res += keys[i];
@@ -227,17 +230,178 @@ String generate_key_str(std::vector<String> keys) {
     return res;
 }
 
+#if SIV3D_PLATFORM(WINDOWS)
+inline bool windows_shortcut_modifier_vk(const int vk) {
+    return vk == VK_SHIFT || vk == VK_LSHIFT || vk == VK_RSHIFT ||
+        vk == VK_CONTROL || vk == VK_LCONTROL || vk == VK_RCONTROL ||
+        vk == VK_MENU || vk == VK_LMENU || vk == VK_RMENU;
+}
+
+inline bool windows_shortcut_scannable_vk(const int vk) {
+    if (vk < VK_BACK || 0xFE < vk) {
+        return false;
+    }
+#ifdef VK_PROCESSKEY
+    if (vk == VK_PROCESSKEY) {
+        return false;
+    }
+#endif
+#ifdef VK_PACKET
+    if (vk == VK_PACKET) {
+        return false;
+    }
+#endif
+    return true;
+}
+
+inline bool windows_shortcut_vk_to_key_name(const int vk, String* key_name) {
+    if ('A' <= vk && vk <= 'Z') {
+        *key_name = Unicode::Widen(std::string(1, static_cast<char>(vk)));
+        return true;
+    }
+    if ('0' <= vk && vk <= '9') {
+        *key_name = Unicode::Widen(std::string(1, static_cast<char>(vk)));
+        return true;
+    }
+    if (VK_NUMPAD0 <= vk && vk <= VK_NUMPAD9) {
+        *key_name = U"Num" + Format(vk - VK_NUMPAD0);
+        return true;
+    }
+    if (VK_F1 <= vk && vk <= VK_F24) {
+        *key_name = U"F" + Format(vk - VK_F1 + 1);
+        return true;
+    }
+
+    switch (vk) {
+    case VK_CANCEL: *key_name = U"Cancel"; return true;
+    case VK_BACK: *key_name = U"Backspace"; return true;
+    case VK_TAB: *key_name = U"Tab"; return true;
+    case VK_CLEAR: *key_name = U"Clear"; return true;
+    case VK_RETURN: *key_name = U"Enter"; return true;
+    case VK_SHIFT: *key_name = U"Shift"; return true;
+    case VK_CONTROL: *key_name = U"Ctrl"; return true;
+    case VK_MENU: *key_name = U"Alt"; return true;
+    case VK_PAUSE: *key_name = U"Pause"; return true;
+    case VK_CAPITAL: *key_name = U"CapsLock"; return true;
+    case VK_KANA: *key_name = U"Kana"; return true;
+#ifdef VK_IME_ON
+    case VK_IME_ON: *key_name = U"IMEOn"; return true;
+#endif
+    case VK_JUNJA: *key_name = U"Junja"; return true;
+    case VK_FINAL: *key_name = U"Final"; return true;
+    case VK_HANJA: *key_name = U"Kanji"; return true;
+#ifdef VK_IME_OFF
+    case VK_IME_OFF: *key_name = U"IMEOff"; return true;
+#endif
+    case VK_ESCAPE: *key_name = U"Escape"; return true;
+    case VK_CONVERT: *key_name = U"Convert"; return true;
+    case VK_NONCONVERT: *key_name = U"NonConvert"; return true;
+    case VK_ACCEPT: *key_name = U"Accept"; return true;
+    case VK_MODECHANGE: *key_name = U"ModeChange"; return true;
+    case VK_SPACE: *key_name = U"Space"; return true;
+    case VK_PRIOR: *key_name = U"PageUp"; return true;
+    case VK_NEXT: *key_name = U"PageDown"; return true;
+    case VK_END: *key_name = U"End"; return true;
+    case VK_HOME: *key_name = U"Home"; return true;
+    case VK_LEFT: *key_name = U"Left"; return true;
+    case VK_UP: *key_name = U"Up"; return true;
+    case VK_RIGHT: *key_name = U"Right"; return true;
+    case VK_DOWN: *key_name = U"Down"; return true;
+    case VK_SELECT: *key_name = U"Select"; return true;
+    case VK_PRINT: *key_name = U"Print"; return true;
+    case VK_EXECUTE: *key_name = U"Execute"; return true;
+    case VK_SNAPSHOT: *key_name = U"PrintScreen"; return true;
+    case VK_INSERT: *key_name = U"Insert"; return true;
+    case VK_DELETE: *key_name = U"Delete"; return true;
+    case VK_HELP: *key_name = U"Help"; return true;
+    case VK_LWIN: *key_name = U"0x5b"; return true;
+    case VK_RWIN: *key_name = U"0x5c"; return true;
+    case VK_APPS: *key_name = U"Apps"; return true;
+    case VK_SLEEP: *key_name = U"Sleep"; return true;
+    case VK_MULTIPLY: *key_name = U"NumMultiply"; return true;
+    case VK_ADD: *key_name = U"NumAdd"; return true;
+    case VK_SEPARATOR: *key_name = U"NumSeparator"; return true;
+    case VK_SUBTRACT: *key_name = U"NumSubtract"; return true;
+    case VK_DECIMAL: *key_name = U"NumDecimal"; return true;
+    case VK_DIVIDE: *key_name = U"NumDivide"; return true;
+    case VK_NUMLOCK: *key_name = U"NumLock"; return true;
+    case VK_SCROLL: *key_name = U"ScrollLock"; return true;
+    case VK_LSHIFT: *key_name = U"Left Shift"; return true;
+    case VK_RSHIFT: *key_name = U"Right Shift"; return true;
+    case VK_LCONTROL: *key_name = U"Left Ctrl"; return true;
+    case VK_RCONTROL: *key_name = U"Right Ctrl"; return true;
+    case VK_LMENU: *key_name = U"Left Alt"; return true;
+    case VK_RMENU: *key_name = U"Right Alt"; return true;
+    case VK_BROWSER_BACK: *key_name = U"BrowserBack"; return true;
+    case VK_BROWSER_FORWARD: *key_name = U"BrowserForward"; return true;
+    case VK_BROWSER_REFRESH: *key_name = U"BrowserRefresh"; return true;
+    case VK_BROWSER_STOP: *key_name = U"BrowserStop"; return true;
+    case VK_BROWSER_SEARCH: *key_name = U"BrowserSearch"; return true;
+    case VK_BROWSER_FAVORITES: *key_name = U"BrowserFavorites"; return true;
+    case VK_BROWSER_HOME: *key_name = U"BrowserHome"; return true;
+    case VK_VOLUME_MUTE: *key_name = U"VolumeMute"; return true;
+    case VK_VOLUME_DOWN: *key_name = U"VolumeDown"; return true;
+    case VK_VOLUME_UP: *key_name = U"VolumeUp"; return true;
+    case VK_MEDIA_NEXT_TRACK: *key_name = U"NextTrack"; return true;
+    case VK_MEDIA_PREV_TRACK: *key_name = U"PreviousTrack"; return true;
+    case VK_MEDIA_STOP: *key_name = U"StopMedia"; return true;
+    case VK_MEDIA_PLAY_PAUSE: *key_name = U"PlayPauseMedia"; return true;
+    case VK_LAUNCH_MAIL: *key_name = U"LaunchMail"; return true;
+    case VK_LAUNCH_MEDIA_SELECT: *key_name = U"LaunchMediaSelect"; return true;
+    case VK_LAUNCH_APP1: *key_name = U"LaunchApp1"; return true;
+    case VK_LAUNCH_APP2: *key_name = U"LaunchApp2"; return true;
+    case VK_OEM_1: *key_name = U"Semicolon"; return true;
+    case VK_OEM_PLUS: *key_name = U"Equal"; return true;
+    case VK_OEM_COMMA: *key_name = U"Comma"; return true;
+    case VK_OEM_MINUS: *key_name = U"Minus"; return true;
+    case VK_OEM_PERIOD: *key_name = U"Period"; return true;
+    case VK_OEM_2: *key_name = U"Slash"; return true;
+    case VK_OEM_3: *key_name = U"GraveAccent"; return true;
+    case VK_OEM_4: *key_name = U"LBracket"; return true;
+    case VK_OEM_5: *key_name = U"Backslash"; return true;
+    case VK_OEM_6: *key_name = U"RBracket"; return true;
+    case VK_OEM_7: *key_name = U"Apostrophe"; return true;
+    case VK_OEM_8: *key_name = U"OEM8"; return true;
+    case VK_OEM_102: *key_name = U"OEM102"; return true;
+    case VK_ATTN: *key_name = U"Attn"; return true;
+    case VK_CRSEL: *key_name = U"CrSel"; return true;
+    case VK_EXSEL: *key_name = U"ExSel"; return true;
+    case VK_EREOF: *key_name = U"EraseEOF"; return true;
+    case VK_PLAY: *key_name = U"Play"; return true;
+    case VK_ZOOM: *key_name = U"Zoom"; return true;
+    case VK_OEM_CLEAR: *key_name = U"OEMClear"; return true;
+    default:
+        return false;
+    }
+}
+#endif
+
 std::vector<String> get_all_inputs(bool *down_found) {
     const Array<Input> raw_keys = Keyboard::GetAllInputs();
     *down_found = false;
     std::unordered_set<String> keys;
     for (const auto& key : raw_keys) {
+        String key_name = key.name();
+#if SIV3D_PLATFORM(WINDOWS)
+        String windows_key_name;
+        if (key.deviceType() == InputDeviceType::Keyboard &&
+            windows_shortcut_vk_to_key_name(static_cast<int>(key.code()), &windows_key_name)) {
+            key_name = windows_key_name;
+        }
+        if (key_name == U"Left Ctrl" || key_name == U"Right Ctrl") {
+            key_name = U"Ctrl";
+        } else if (key_name == U"Left Shift" || key_name == U"Right Shift") {
+            key_name = U"Shift";
+        } else if (key_name == U"Left Alt" || key_name == U"Right Alt") {
+            key_name = U"Alt";
+        }
+#endif
         // ignored keys
-        if (ignore_keys.contains(key.name())) {
+        if (ignore_keys.contains(key_name)) {
             continue;
         }
         *down_found |= key.down();
-        keys.emplace(key.name());
+        keys.emplace(key_name);
     }
     std::vector<String> res;
     if (keys.find(U"Ctrl") != keys.end()) {
@@ -258,10 +422,70 @@ std::vector<String> get_all_inputs(bool *down_found) {
     return res;
 }
 
+inline std::string shortcut_key_list_to_string(const std::vector<String>& keys) {
+    std::string res;
+    for (int i = 0; i < (int)keys.size(); ++i) {
+        if (i) {
+            res += "+";
+        }
+        res += keys[i].narrow();
+    }
+    return res;
+}
+
 #if SIV3D_PLATFORM(WINDOWS)
+inline String windows_shortcut_key_token(const String& key_name) {
+    const String trimmed = key_name.trimmed();
+    String token;
+    for (const char32 ch : trimmed) {
+        if (ch == U' ' || ch == U'_') {
+            continue;
+        }
+        if (U'a' <= ch && ch <= U'z') {
+            token += static_cast<char32>(U'A' + (ch - U'a'));
+        } else {
+            token += ch;
+        }
+    }
+    return token;
+}
+
+inline bool windows_shortcut_parse_hex_vk(const String& key_name, int* vk) {
+    const String trimmed = key_name.trimmed();
+    if (trimmed.size() < 3 || trimmed[0] != U'0' || (trimmed[1] != U'x' && trimmed[1] != U'X')) {
+        return false;
+    }
+
+    int value = 0;
+    for (size_t i = 2; i < trimmed.size(); ++i) {
+        const char32 ch = trimmed[i];
+        int digit = -1;
+        if (U'0' <= ch && ch <= U'9') {
+            digit = static_cast<int>(ch - U'0');
+        } else if (U'a' <= ch && ch <= U'f') {
+            digit = 10 + static_cast<int>(ch - U'a');
+        } else if (U'A' <= ch && ch <= U'F') {
+            digit = 10 + static_cast<int>(ch - U'A');
+        } else {
+            return false;
+        }
+        value = value * 16 + digit;
+        if (value > 0xFE) {
+            return false;
+        }
+    }
+
+    if (!windows_shortcut_scannable_vk(value)) {
+        return false;
+    }
+    *vk = value;
+    return true;
+}
+
 inline bool shortcut_key_name_to_windows_vk(const String& key_name, int* vk) {
-    if (key_name.size() == 1) {
-        const char32 ch = key_name[0];
+    const String trimmed = key_name.trimmed();
+    if (trimmed.size() == 1) {
+        const char32 ch = trimmed[0];
         if (U'A' <= ch && ch <= U'Z') {
             *vk = static_cast<int>('A' + (ch - U'A'));
             return true;
@@ -274,38 +498,348 @@ inline bool shortcut_key_name_to_windows_vk(const String& key_name, int* vk) {
             *vk = static_cast<int>('0' + (ch - U'0'));
             return true;
         }
+        switch (ch) {
+        case U';':
+        case U':':
+            *vk = VK_OEM_1;
+            return true;
+        case U'=':
+        case U'+':
+            *vk = VK_OEM_PLUS;
+            return true;
+        case U',':
+        case U'<':
+            *vk = VK_OEM_COMMA;
+            return true;
+        case U'-':
+            *vk = VK_OEM_MINUS;
+            return true;
+        case U'.':
+        case U'>':
+            *vk = VK_OEM_PERIOD;
+            return true;
+        case U'/':
+        case U'?':
+            *vk = VK_OEM_2;
+            return true;
+        case U'`':
+        case U'~':
+            *vk = VK_OEM_3;
+            return true;
+        case U'[':
+        case U'{':
+            *vk = VK_OEM_4;
+            return true;
+        case U'\\':
+        case U'|':
+            *vk = VK_OEM_5;
+            return true;
+        case U']':
+        case U'}':
+            *vk = VK_OEM_6;
+            return true;
+        case U'\'':
+        case U'"':
+        case U'^':
+            *vk = VK_OEM_7;
+            return true;
+        default:
+            break;
+        }
+    }
+
+    if (windows_shortcut_parse_hex_vk(trimmed, vk)) {
+        return true;
+    }
+
+    const String token = windows_shortcut_key_token(trimmed);
+    if (token.size() >= 2 && token[0] == U'F') {
+        int function_key_number = 0;
+        bool valid_function_key_name = true;
+        for (size_t i = 1; i < token.size(); ++i) {
+            const char32 ch = token[i];
+            if (ch < U'0' || U'9' < ch) {
+                valid_function_key_name = false;
+                break;
+            }
+            function_key_number = function_key_number * 10 + static_cast<int>(ch - U'0');
+        }
+        if (valid_function_key_name && 1 <= function_key_number && function_key_number <= 24) {
+            *vk = VK_F1 + function_key_number - 1;
+            return true;
+        }
+    }
+
+    auto parse_numpad_digit = [&](const String& prefix) {
+        if (!token.starts_with(prefix) || token.size() != prefix.size() + 1) {
+            return false;
+        }
+        const char32 digit = token[prefix.size()];
+        if (digit < U'0' || U'9' < digit) {
+            return false;
+        }
+        *vk = VK_NUMPAD0 + static_cast<int>(digit - U'0');
+        return true;
+    };
+    if (parse_numpad_digit(U"NUM") || parse_numpad_digit(U"NUMPAD") || parse_numpad_digit(U"KEYNUM")) {
+        return true;
     }
 
     static const std::unordered_map<String, int> key_map = {
         {U"Ctrl", VK_CONTROL},
+        {U"CTRL", VK_CONTROL},
+        {U"CONTROL", VK_CONTROL},
         {U"Left Ctrl", VK_LCONTROL},
+        {U"LEFTCTRL", VK_LCONTROL},
+        {U"LCTRL", VK_LCONTROL},
+        {U"LCONTROL", VK_LCONTROL},
         {U"Right Ctrl", VK_RCONTROL},
+        {U"RIGHTCTRL", VK_RCONTROL},
+        {U"RCTRL", VK_RCONTROL},
+        {U"RCONTROL", VK_RCONTROL},
         {U"Shift", VK_SHIFT},
+        {U"SHIFT", VK_SHIFT},
         {U"Left Shift", VK_LSHIFT},
+        {U"LEFTSHIFT", VK_LSHIFT},
+        {U"LSHIFT", VK_LSHIFT},
         {U"Right Shift", VK_RSHIFT},
+        {U"RIGHTSHIFT", VK_RSHIFT},
+        {U"RSHIFT", VK_RSHIFT},
         {U"Alt", VK_MENU},
+        {U"ALT", VK_MENU},
+        {U"MENU", VK_MENU},
         {U"Left Alt", VK_LMENU},
+        {U"LEFTALT", VK_LMENU},
+        {U"LALT", VK_LMENU},
+        {U"LMENU", VK_LMENU},
         {U"Right Alt", VK_RMENU},
+        {U"RIGHTALT", VK_RMENU},
+        {U"RALT", VK_RMENU},
+        {U"RMENU", VK_RMENU},
         {U"Space", VK_SPACE},
+        {U"SPACE", VK_SPACE},
         {U"Backspace", VK_BACK},
+        {U"BACKSPACE", VK_BACK},
+        {U"BACK", VK_BACK},
         {U"Tab", VK_TAB},
+        {U"TAB", VK_TAB},
         {U"Enter", VK_RETURN},
+        {U"ENTER", VK_RETURN},
+        {U"RETURN", VK_RETURN},
         {U"Escape", VK_ESCAPE},
+        {U"ESCAPE", VK_ESCAPE},
+        {U"ESC", VK_ESCAPE},
         {U"Left", VK_LEFT},
+        {U"LEFT", VK_LEFT},
         {U"Right", VK_RIGHT},
+        {U"RIGHT", VK_RIGHT},
         {U"Up", VK_UP},
+        {U"UP", VK_UP},
         {U"Down", VK_DOWN},
+        {U"DOWN", VK_DOWN},
         {U"Home", VK_HOME},
+        {U"HOME", VK_HOME},
         {U"End", VK_END},
+        {U"END", VK_END},
         {U"PageUp", VK_PRIOR},
+        {U"PAGEUP", VK_PRIOR},
+        {U"PGUP", VK_PRIOR},
+        {U"PRIOR", VK_PRIOR},
         {U"PageDown", VK_NEXT},
+        {U"PAGEDOWN", VK_NEXT},
+        {U"PGDN", VK_NEXT},
+        {U"NEXT", VK_NEXT},
         {U"Insert", VK_INSERT},
+        {U"INSERT", VK_INSERT},
+        {U"INS", VK_INSERT},
         {U"Delete", VK_DELETE},
+        {U"DELETE", VK_DELETE},
+        {U"DEL", VK_DELETE},
+        {U"Cancel", VK_CANCEL},
+        {U"CANCEL", VK_CANCEL},
+        {U"Clear", VK_CLEAR},
+        {U"CLEAR", VK_CLEAR},
+        {U"Pause", VK_PAUSE},
+        {U"PAUSE", VK_PAUSE},
+        {U"CapsLock", VK_CAPITAL},
+        {U"CAPSLOCK", VK_CAPITAL},
+        {U"Kana", VK_KANA},
+        {U"KANA", VK_KANA},
+        {U"HANGUL", VK_KANA},
+#ifdef VK_IME_ON
+        {U"IMEOn", VK_IME_ON},
+        {U"IMEON", VK_IME_ON},
+#endif
+        {U"Junja", VK_JUNJA},
+        {U"JUNJA", VK_JUNJA},
+        {U"Final", VK_FINAL},
+        {U"FINAL", VK_FINAL},
+        {U"Kanji", VK_HANJA},
+        {U"KANJI", VK_HANJA},
+        {U"HANJA", VK_HANJA},
+#ifdef VK_IME_OFF
+        {U"IMEOff", VK_IME_OFF},
+        {U"IMEOFF", VK_IME_OFF},
+#endif
+        {U"Convert", VK_CONVERT},
+        {U"CONVERT", VK_CONVERT},
+        {U"NonConvert", VK_NONCONVERT},
+        {U"NONCONVERT", VK_NONCONVERT},
+        {U"Accept", VK_ACCEPT},
+        {U"ACCEPT", VK_ACCEPT},
+        {U"ModeChange", VK_MODECHANGE},
+        {U"MODECHANGE", VK_MODECHANGE},
+        {U"Print", VK_PRINT},
+        {U"PRINT", VK_PRINT},
+        {U"PrintScreen", VK_SNAPSHOT},
+        {U"PRINTSCREEN", VK_SNAPSHOT},
+        {U"PRTSC", VK_SNAPSHOT},
+        {U"Select", VK_SELECT},
+        {U"SELECT", VK_SELECT},
+        {U"Execute", VK_EXECUTE},
+        {U"EXECUTE", VK_EXECUTE},
+        {U"Help", VK_HELP},
+        {U"HELP", VK_HELP},
         {U"0x5b", VK_LWIN},
+        {U"0X5B", VK_LWIN},
+        {U"Left Windows", VK_LWIN},
+        {U"LEFTWINDOWS", VK_LWIN},
+        {U"LWIN", VK_LWIN},
+        {U"Left Command", VK_LWIN},
+        {U"LEFTCOMMAND", VK_LWIN},
+        {U"0x5c", VK_RWIN},
+        {U"0X5C", VK_RWIN},
+        {U"Right Windows", VK_RWIN},
+        {U"RIGHTWINDOWS", VK_RWIN},
+        {U"RWIN", VK_RWIN},
+        {U"Right Command", VK_RWIN},
+        {U"RIGHTCOMMAND", VK_RWIN},
+        {U"Apps", VK_APPS},
+        {U"APPS", VK_APPS},
+        {U"Sleep", VK_SLEEP},
+        {U"SLEEP", VK_SLEEP},
+        {U"NumMultiply", VK_MULTIPLY},
+        {U"NUMMULTIPLY", VK_MULTIPLY},
+        {U"NUMSTAR", VK_MULTIPLY},
+        {U"NumAdd", VK_ADD},
+        {U"NUMADD", VK_ADD},
+        {U"NUMPLUS", VK_ADD},
+        {U"NumSeparator", VK_SEPARATOR},
+        {U"NUMSEPARATOR", VK_SEPARATOR},
+        {U"NumSubtract", VK_SUBTRACT},
+        {U"NUMSUBTRACT", VK_SUBTRACT},
+        {U"NUMMINUS", VK_SUBTRACT},
+        {U"NumDecimal", VK_DECIMAL},
+        {U"NUMDECIMAL", VK_DECIMAL},
+        {U"NUMPERIOD", VK_DECIMAL},
+        {U"NumDivide", VK_DIVIDE},
+        {U"NUMDIVIDE", VK_DIVIDE},
+        {U"NUMSLASH", VK_DIVIDE},
+        {U"NumLock", VK_NUMLOCK},
+        {U"NUMLOCK", VK_NUMLOCK},
+        {U"ScrollLock", VK_SCROLL},
+        {U"SCROLLLOCK", VK_SCROLL},
+        {U"NextTrack", VK_MEDIA_NEXT_TRACK},
+        {U"NEXTTRACK", VK_MEDIA_NEXT_TRACK},
+        {U"PreviousTrack", VK_MEDIA_PREV_TRACK},
+        {U"PREVIOUSTRACK", VK_MEDIA_PREV_TRACK},
+        {U"StopMedia", VK_MEDIA_STOP},
+        {U"STOPMEDIA", VK_MEDIA_STOP},
+        {U"PlayPauseMedia", VK_MEDIA_PLAY_PAUSE},
+        {U"PLAYPAUSEMEDIA", VK_MEDIA_PLAY_PAUSE},
+        {U"BrowserBack", VK_BROWSER_BACK},
+        {U"BROWSERBACK", VK_BROWSER_BACK},
+        {U"BrowserForward", VK_BROWSER_FORWARD},
+        {U"BROWSERFORWARD", VK_BROWSER_FORWARD},
+        {U"BrowserRefresh", VK_BROWSER_REFRESH},
+        {U"BROWSERREFRESH", VK_BROWSER_REFRESH},
+        {U"BrowserStop", VK_BROWSER_STOP},
+        {U"BROWSERSTOP", VK_BROWSER_STOP},
+        {U"BrowserSearch", VK_BROWSER_SEARCH},
+        {U"BROWSERSEARCH", VK_BROWSER_SEARCH},
+        {U"BrowserFavorites", VK_BROWSER_FAVORITES},
+        {U"BROWSERFAVORITES", VK_BROWSER_FAVORITES},
+        {U"BrowserHome", VK_BROWSER_HOME},
+        {U"BROWSERHOME", VK_BROWSER_HOME},
+        {U"VolumeMute", VK_VOLUME_MUTE},
+        {U"VOLUMEMUTE", VK_VOLUME_MUTE},
+        {U"VolumeDown", VK_VOLUME_DOWN},
+        {U"VOLUMEDOWN", VK_VOLUME_DOWN},
+        {U"VolumeUp", VK_VOLUME_UP},
+        {U"VOLUMEUP", VK_VOLUME_UP},
+        {U"LaunchMail", VK_LAUNCH_MAIL},
+        {U"LAUNCHMAIL", VK_LAUNCH_MAIL},
+        {U"LaunchMediaSelect", VK_LAUNCH_MEDIA_SELECT},
+        {U"LAUNCHMEDIASELECT", VK_LAUNCH_MEDIA_SELECT},
+        {U"LaunchApp1", VK_LAUNCH_APP1},
+        {U"LAUNCHAPP1", VK_LAUNCH_APP1},
+        {U"LaunchApp2", VK_LAUNCH_APP2},
+        {U"LAUNCHAPP2", VK_LAUNCH_APP2},
+        {U"Semicolon", VK_OEM_1},
+        {U"SEMICOLON", VK_OEM_1},
+        {U"Semicolon_US", VK_OEM_1},
+        {U"SEMICOLONUS", VK_OEM_1},
+        {U"Colon_JIS", VK_OEM_1},
+        {U"COLONJIS", VK_OEM_1},
+        {U"Equal", VK_OEM_PLUS},
+        {U"EQUAL", VK_OEM_PLUS},
+        {U"Equal_US", VK_OEM_PLUS},
+        {U"EQUALUS", VK_OEM_PLUS},
+        {U"Semicolon_JIS", VK_OEM_PLUS},
+        {U"SEMICOLONJIS", VK_OEM_PLUS},
+        {U"Comma", VK_OEM_COMMA},
+        {U"COMMA", VK_OEM_COMMA},
+        {U"Minus", VK_OEM_MINUS},
+        {U"MINUS", VK_OEM_MINUS},
+        {U"Period", VK_OEM_PERIOD},
+        {U"PERIOD", VK_OEM_PERIOD},
+        {U"Slash", VK_OEM_2},
+        {U"SLASH", VK_OEM_2},
+        {U"GraveAccent", VK_OEM_3},
+        {U"GRAVEACCENT", VK_OEM_3},
+        {U"LBracket", VK_OEM_4},
+        {U"LBRACKET", VK_OEM_4},
+        {U"LeftBracket", VK_OEM_4},
+        {U"LEFTBRACKET", VK_OEM_4},
+        {U"Backslash", VK_OEM_5},
+        {U"BACKSLASH", VK_OEM_5},
+        {U"Yen_JIS", VK_OEM_5},
+        {U"YENJIS", VK_OEM_5},
+        {U"RBracket", VK_OEM_6},
+        {U"RBRACKET", VK_OEM_6},
+        {U"RightBracket", VK_OEM_6},
+        {U"RIGHTBRACKET", VK_OEM_6},
+        {U"Apostrophe", VK_OEM_7},
+        {U"APOSTROPHE", VK_OEM_7},
+        {U"Apostrophe_US", VK_OEM_7},
+        {U"APOSTROPHEUS", VK_OEM_7},
+        {U"Caret_JIS", VK_OEM_7},
+        {U"CARETJIS", VK_OEM_7},
+        {U"OEM8", VK_OEM_8},
+        {U"OEM102", VK_OEM_102},
+        {U"Underscore_JIS", VK_OEM_102},
+        {U"UNDERSCOREJIS", VK_OEM_102},
+        {U"Attn", VK_ATTN},
+        {U"ATTN", VK_ATTN},
+        {U"CrSel", VK_CRSEL},
+        {U"CRSEL", VK_CRSEL},
+        {U"ExSel", VK_EXSEL},
+        {U"EXSEL", VK_EXSEL},
+        {U"EraseEOF", VK_EREOF},
+        {U"ERASEEOF", VK_EREOF},
+        {U"Play", VK_PLAY},
+        {U"PLAY", VK_PLAY},
+        {U"Zoom", VK_ZOOM},
+        {U"ZOOM", VK_ZOOM},
+        {U"OEMClear", VK_OEM_CLEAR},
+        {U"OEMCLEAR", VK_OEM_CLEAR},
     };
 
-    const auto it = key_map.find(key_name);
+    auto it = key_map.find(trimmed);
     if (it == key_map.end()) {
+        it = key_map.find(token);
+    }
+    if (it == key_map.end() || !windows_shortcut_scannable_vk(it->second)) {
         return false;
     }
     *vk = it->second;
@@ -316,42 +850,126 @@ inline bool windows_vk_pressed(int vk) {
     return (GetAsyncKeyState(vk) & 0x8000) != 0;
 }
 
-inline bool windows_shortcut_modifier_state_matches(const std::vector<String>& keys) {
-    const bool needs_ctrl = (std::find(keys.begin(), keys.end(), U"Ctrl") != keys.end()) ||
-        (std::find(keys.begin(), keys.end(), U"Left Ctrl") != keys.end()) ||
-        (std::find(keys.begin(), keys.end(), U"Right Ctrl") != keys.end());
-    const bool needs_shift = (std::find(keys.begin(), keys.end(), U"Shift") != keys.end()) ||
-        (std::find(keys.begin(), keys.end(), U"Left Shift") != keys.end()) ||
-        (std::find(keys.begin(), keys.end(), U"Right Shift") != keys.end());
-    const bool needs_alt = (std::find(keys.begin(), keys.end(), U"Alt") != keys.end()) ||
-        (std::find(keys.begin(), keys.end(), U"Left Alt") != keys.end()) ||
-        (std::find(keys.begin(), keys.end(), U"Right Alt") != keys.end());
+struct Windows_shortcut_keyboard_state {
+    bool focused = false;
+    std::unordered_set<int> pressed_vks;
+    std::unordered_set<int> down_vks;
+};
 
-    return windows_vk_pressed(VK_CONTROL) == needs_ctrl &&
-        windows_vk_pressed(VK_SHIFT) == needs_shift &&
-        windows_vk_pressed(VK_MENU) == needs_alt;
+inline Windows_shortcut_keyboard_state get_windows_shortcut_keyboard_state() {
+    static std::unordered_set<int> previous_pressed_vks;
+    static bool previous_focused = false;
+
+    Windows_shortcut_keyboard_state state;
+    state.focused = Window::GetState().focused;
+    for (int vk = VK_BACK; vk <= 0xFE; ++vk) {
+        if (windows_shortcut_scannable_vk(vk) && windows_vk_pressed(vk)) {
+            state.pressed_vks.emplace(vk);
+        }
+    }
+
+    if (state.focused && previous_focused) {
+        for (const int vk : state.pressed_vks) {
+            if (previous_pressed_vks.find(vk) == previous_pressed_vks.end()) {
+                state.down_vks.emplace(vk);
+            }
+        }
+    }
+
+    previous_pressed_vks = state.pressed_vks;
+    previous_focused = state.focused;
+    return state;
 }
 
-inline bool windows_shortcut_non_modifier_state_matches(const std::unordered_set<int>& expected_vks) {
-    static const int non_modifier_vks[] = {
-        VK_SPACE, VK_BACK, VK_TAB, VK_RETURN, VK_ESCAPE,
-        VK_LEFT, VK_RIGHT, VK_UP, VK_DOWN,
-        VK_HOME, VK_END, VK_PRIOR, VK_NEXT, VK_INSERT, VK_DELETE,
-        VK_LWIN,
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-    };
+inline bool windows_shortcut_vk_pressed(const Windows_shortcut_keyboard_state& keyboard_state, const int vk) {
+    return keyboard_state.pressed_vks.find(vk) != keyboard_state.pressed_vks.end();
+}
 
-    for (const int vk : non_modifier_vks) {
-        if (windows_vk_pressed(vk) && expected_vks.find(vk) == expected_vks.end()) {
+inline bool windows_shortcut_vk_down(const Windows_shortcut_keyboard_state& keyboard_state, const int vk) {
+    return keyboard_state.down_vks.find(vk) != keyboard_state.down_vks.end();
+}
+
+inline bool windows_shortcut_key_name_found(const std::vector<String>& keys, const String& key_name) {
+    const String expected_token = windows_shortcut_key_token(key_name);
+    for (const String& key : keys) {
+        if (windows_shortcut_key_token(key) == expected_token) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool windows_shortcut_modifier_family_matches(
+    const Windows_shortcut_keyboard_state& keyboard_state,
+    const std::vector<String>& keys,
+    const String& generic_name,
+    const String& left_name,
+    const String& right_name,
+    const int generic_vk,
+    const int left_vk,
+    const int right_vk
+) {
+    const bool needs_generic = windows_shortcut_key_name_found(keys, generic_name);
+    const bool needs_left = windows_shortcut_key_name_found(keys, left_name);
+    const bool needs_right = windows_shortcut_key_name_found(keys, right_name);
+    const bool generic_pressed = windows_shortcut_vk_pressed(keyboard_state, generic_vk);
+    const bool left_pressed = windows_shortcut_vk_pressed(keyboard_state, left_vk);
+    const bool right_pressed = windows_shortcut_vk_pressed(keyboard_state, right_vk);
+    const bool any_pressed = generic_pressed || left_pressed || right_pressed;
+
+    if (!needs_generic && !needs_left && !needs_right) {
+        return !any_pressed;
+    }
+    if (needs_left || needs_right) {
+        return left_pressed == needs_left && right_pressed == needs_right;
+    }
+
+    const int physical_count = (left_pressed ? 1 : 0) + (right_pressed ? 1 : 0);
+    if (physical_count > 1) {
+        return false;
+    }
+    return any_pressed;
+}
+
+inline bool windows_shortcut_modifier_state_matches(
+    const Windows_shortcut_keyboard_state& keyboard_state,
+    const std::vector<String>& keys
+) {
+    return windows_shortcut_modifier_family_matches(keyboard_state, keys, U"Ctrl", U"Left Ctrl", U"Right Ctrl", VK_CONTROL, VK_LCONTROL, VK_RCONTROL) &&
+        windows_shortcut_modifier_family_matches(keyboard_state, keys, U"Shift", U"Left Shift", U"Right Shift", VK_SHIFT, VK_LSHIFT, VK_RSHIFT) &&
+        windows_shortcut_modifier_family_matches(keyboard_state, keys, U"Alt", U"Left Alt", U"Right Alt", VK_MENU, VK_LMENU, VK_RMENU);
+}
+
+inline bool windows_shortcut_non_modifier_state_matches(
+    const Windows_shortcut_keyboard_state& keyboard_state,
+    const std::unordered_set<int>& expected_vks
+) {
+    for (const int vk : keyboard_state.pressed_vks) {
+        if (!windows_shortcut_modifier_vk(vk) && expected_vks.find(vk) == expected_vks.end()) {
             return false;
         }
     }
     return true;
 }
 
-inline bool check_windows_shortcut_key_state(const Shortcut_key_elem& elem, bool* down_found, bool* pressed_found) {
+inline bool windows_shortcut_expected_key_down_found(
+    const Windows_shortcut_keyboard_state& keyboard_state,
+    const std::unordered_set<int>& expected_vks
+) {
+    for (const int vk : expected_vks) {
+        if (windows_shortcut_vk_down(keyboard_state, vk)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool check_windows_shortcut_key_state(
+    const Shortcut_key_elem& elem,
+    const Windows_shortcut_keyboard_state& keyboard_state,
+    bool* down_found,
+    bool* pressed_found
+) {
     *down_found = false;
     *pressed_found = false;
     if (elem.keys.empty()) {
@@ -367,28 +985,127 @@ inline bool check_windows_shortcut_key_state(const Shortcut_key_elem& elem, bool
         expected_vks.emplace(vk);
     }
 
-    static std::unordered_map<String, bool> previous_pressed;
-    if (!Window::GetState().focused) {
-        previous_pressed[elem.name] = false;
+    if (!keyboard_state.focused) {
         return true;
     }
 
-    bool pressed = windows_shortcut_modifier_state_matches(elem.keys) &&
-        windows_shortcut_non_modifier_state_matches(expected_vks);
+    bool pressed = windows_shortcut_modifier_state_matches(keyboard_state, elem.keys) &&
+        windows_shortcut_non_modifier_state_matches(keyboard_state, expected_vks);
     for (const String& key : elem.keys) {
         int vk = 0;
         shortcut_key_name_to_windows_vk(key, &vk);
-        pressed &= windows_vk_pressed(vk);
+        pressed &= windows_shortcut_vk_pressed(keyboard_state, vk);
     }
 
-    const bool previous = previous_pressed[elem.name];
-    previous_pressed[elem.name] = pressed;
-
     *pressed_found = pressed;
-    *down_found = pressed && !previous;
+    *down_found = pressed && windows_shortcut_expected_key_down_found(keyboard_state, expected_vks);
     return true;
 }
+
+inline std::vector<String> get_windows_shortcut_inputs_for_diagnostics() {
+    std::vector<String> keys;
+    auto append_if_pressed = [&](const String& name, const int vk) {
+        if (windows_vk_pressed(vk)) {
+            keys.emplace_back(name);
+        }
+    };
+
+    append_if_pressed(U"Ctrl", VK_CONTROL);
+    append_if_pressed(U"Shift", VK_SHIFT);
+    append_if_pressed(U"Alt", VK_MENU);
+
+    for (int vk = VK_BACK; vk <= 0xFE; ++vk) {
+        if (!windows_shortcut_scannable_vk(vk) || windows_shortcut_modifier_vk(vk) || !windows_vk_pressed(vk)) {
+            continue;
+        }
+        String key_name;
+        if (windows_shortcut_vk_to_key_name(vk, &key_name)) {
+            keys.emplace_back(key_name);
+        }
+    }
+    return keys;
+}
 #endif
+
+inline void shortcut_diagnostic_log(
+    const std::vector<String>& raw_keys,
+    const bool raw_down_found,
+    const String& shortcut_name_down,
+    const String& shortcut_name_pressed
+) {
+#if SIV3D_PLATFORM(WINDOWS)
+    char* env_path = nullptr;
+    size_t env_path_size = 0;
+    if (_dupenv_s(&env_path, &env_path_size, "EGAROUCID_SHORTCUT_DIAG_LOG") != 0 || env_path == nullptr || env_path[0] == '\0') {
+        if (env_path) {
+            free(env_path);
+        }
+        return;
+    }
+    const std::string path = env_path;
+    free(env_path);
+#else
+    const char* env_path = std::getenv("EGAROUCID_SHORTCUT_DIAG_LOG");
+    if (env_path == nullptr || env_path[0] == '\0') {
+        return;
+    }
+    const std::string path = env_path;
+#endif
+
+    std::string raw = shortcut_key_list_to_string(raw_keys);
+#if SIV3D_PLATFORM(WINDOWS)
+    std::string normalized = shortcut_key_list_to_string(get_windows_shortcut_inputs_for_diagnostics());
+#else
+    std::string normalized = raw;
+#endif
+    if (raw.empty() && normalized.empty() &&
+        shortcut_name_down == SHORTCUT_KEY_UNDEFINED &&
+        shortcut_name_pressed == SHORTCUT_KEY_UNDEFINED) {
+        return;
+    }
+
+    static std::string previous_line;
+    std::ostringstream oss;
+    oss << "raw=" << raw
+        << "\trawDown=" << (raw_down_found ? "1" : "0")
+        << "\twin=" << normalized
+        << "\tdown=" << shortcut_name_down.narrow()
+        << "\tpressed=" << shortcut_name_pressed.narrow();
+
+    const std::string line = oss.str();
+    if (line == previous_line) {
+        return;
+    }
+    previous_line = line;
+
+    std::ofstream fout(path, std::ios::app);
+    if (fout) {
+        fout << line << '\n';
+    }
+}
+
+inline bool shortcut_diagnostic_only_mode() {
+#if SIV3D_PLATFORM(WINDOWS)
+    char* value = nullptr;
+    size_t value_size = 0;
+    const bool enabled = (_dupenv_s(&value, &value_size, "EGAROUCID_SHORTCUT_DIAG_ONLY") == 0 &&
+        value != nullptr && value[0] == '1' && value[1] == '\0');
+    if (value) {
+        free(value);
+    }
+    return enabled;
+#else
+    const char* value = std::getenv("EGAROUCID_SHORTCUT_DIAG_ONLY");
+    return value != nullptr && value[0] == '1' && value[1] == '\0';
+#endif
+}
+
+inline void clear_shortcut_result_for_diagnostic_only(String* shortcut_name_down, String* shortcut_name_pressed) {
+    if (shortcut_diagnostic_only_mode()) {
+        *shortcut_name_down = SHORTCUT_KEY_UNDEFINED;
+        *shortcut_name_pressed = SHORTCUT_KEY_UNDEFINED;
+    }
+}
 
 class Shortcut_keys {
 public:
@@ -529,16 +1246,21 @@ public:
         std::vector<String> keys = get_all_inputs(&down_found);
         *shortcut_name_down = SHORTCUT_KEY_UNDEFINED;
         *shortcut_name_pressed = SHORTCUT_KEY_UNDEFINED;
+#if SIV3D_PLATFORM(WINDOWS)
+        const Windows_shortcut_keyboard_state windows_keyboard_state = get_windows_shortcut_keyboard_state();
+#endif
         for (const Shortcut_key_elem &elem: shortcut_keys) {
 #if SIV3D_PLATFORM(WINDOWS)
             bool windows_down_found = false;
             bool windows_pressed_found = false;
-            if (check_windows_shortcut_key_state(elem, &windows_down_found, &windows_pressed_found)) {
+            if (check_windows_shortcut_key_state(elem, windows_keyboard_state, &windows_down_found, &windows_pressed_found)) {
                 if (windows_pressed_found) {
                     if (windows_down_found) {
                         *shortcut_name_down = elem.name;
                     }
                     *shortcut_name_pressed = elem.name;
+                    shortcut_diagnostic_log(keys, down_found, *shortcut_name_down, *shortcut_name_pressed);
+                    clear_shortcut_result_for_diagnostic_only(shortcut_name_down, shortcut_name_pressed);
                     return;
                 }
                 continue;
@@ -557,10 +1279,13 @@ public:
                         *shortcut_name_down = elem.name;
                     }
                     *shortcut_name_pressed = elem.name;
+                    shortcut_diagnostic_log(keys, down_found, *shortcut_name_down, *shortcut_name_pressed);
+                    clear_shortcut_result_for_diagnostic_only(shortcut_name_down, shortcut_name_pressed);
                     return;
                 }
             }
         }
+        shortcut_diagnostic_log(keys, down_found, *shortcut_name_down, *shortcut_name_pressed);
     }
 
     String get_shortcut_key_str(String name) {

--- a/src/gui/function/shortcut_key.hpp
+++ b/src/gui/function/shortcut_key.hpp
@@ -17,6 +17,12 @@
 #include "const/gui_common.hpp"
 #include "ai_profile.hpp"
 #include "language.hpp"
+#if SIV3D_PLATFORM(WINDOWS)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#endif
 
 #define SHORTCUT_KEY_UNDEFINED U"undefined"
 #define SHORTCUT_KEY_AI_PROFILE_PREFIX U"ai_profile:"
@@ -252,6 +258,138 @@ std::vector<String> get_all_inputs(bool *down_found) {
     return res;
 }
 
+#if SIV3D_PLATFORM(WINDOWS)
+inline bool shortcut_key_name_to_windows_vk(const String& key_name, int* vk) {
+    if (key_name.size() == 1) {
+        const char32 ch = key_name[0];
+        if (U'A' <= ch && ch <= U'Z') {
+            *vk = static_cast<int>('A' + (ch - U'A'));
+            return true;
+        }
+        if (U'a' <= ch && ch <= U'z') {
+            *vk = static_cast<int>('A' + (ch - U'a'));
+            return true;
+        }
+        if (U'0' <= ch && ch <= U'9') {
+            *vk = static_cast<int>('0' + (ch - U'0'));
+            return true;
+        }
+    }
+
+    static const std::unordered_map<String, int> key_map = {
+        {U"Ctrl", VK_CONTROL},
+        {U"Left Ctrl", VK_LCONTROL},
+        {U"Right Ctrl", VK_RCONTROL},
+        {U"Shift", VK_SHIFT},
+        {U"Left Shift", VK_LSHIFT},
+        {U"Right Shift", VK_RSHIFT},
+        {U"Alt", VK_MENU},
+        {U"Left Alt", VK_LMENU},
+        {U"Right Alt", VK_RMENU},
+        {U"Space", VK_SPACE},
+        {U"Backspace", VK_BACK},
+        {U"Tab", VK_TAB},
+        {U"Enter", VK_RETURN},
+        {U"Escape", VK_ESCAPE},
+        {U"Left", VK_LEFT},
+        {U"Right", VK_RIGHT},
+        {U"Up", VK_UP},
+        {U"Down", VK_DOWN},
+        {U"Home", VK_HOME},
+        {U"End", VK_END},
+        {U"PageUp", VK_PRIOR},
+        {U"PageDown", VK_NEXT},
+        {U"Insert", VK_INSERT},
+        {U"Delete", VK_DELETE},
+        {U"0x5b", VK_LWIN},
+    };
+
+    const auto it = key_map.find(key_name);
+    if (it == key_map.end()) {
+        return false;
+    }
+    *vk = it->second;
+    return true;
+}
+
+inline bool windows_vk_pressed(int vk) {
+    return (GetAsyncKeyState(vk) & 0x8000) != 0;
+}
+
+inline bool windows_shortcut_modifier_state_matches(const std::vector<String>& keys) {
+    const bool needs_ctrl = (std::find(keys.begin(), keys.end(), U"Ctrl") != keys.end()) ||
+        (std::find(keys.begin(), keys.end(), U"Left Ctrl") != keys.end()) ||
+        (std::find(keys.begin(), keys.end(), U"Right Ctrl") != keys.end());
+    const bool needs_shift = (std::find(keys.begin(), keys.end(), U"Shift") != keys.end()) ||
+        (std::find(keys.begin(), keys.end(), U"Left Shift") != keys.end()) ||
+        (std::find(keys.begin(), keys.end(), U"Right Shift") != keys.end());
+    const bool needs_alt = (std::find(keys.begin(), keys.end(), U"Alt") != keys.end()) ||
+        (std::find(keys.begin(), keys.end(), U"Left Alt") != keys.end()) ||
+        (std::find(keys.begin(), keys.end(), U"Right Alt") != keys.end());
+
+    return windows_vk_pressed(VK_CONTROL) == needs_ctrl &&
+        windows_vk_pressed(VK_SHIFT) == needs_shift &&
+        windows_vk_pressed(VK_MENU) == needs_alt;
+}
+
+inline bool windows_shortcut_non_modifier_state_matches(const std::unordered_set<int>& expected_vks) {
+    static const int non_modifier_vks[] = {
+        VK_SPACE, VK_BACK, VK_TAB, VK_RETURN, VK_ESCAPE,
+        VK_LEFT, VK_RIGHT, VK_UP, VK_DOWN,
+        VK_HOME, VK_END, VK_PRIOR, VK_NEXT, VK_INSERT, VK_DELETE,
+        VK_LWIN,
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    };
+
+    for (const int vk : non_modifier_vks) {
+        if (windows_vk_pressed(vk) && expected_vks.find(vk) == expected_vks.end()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline bool check_windows_shortcut_key_state(const Shortcut_key_elem& elem, bool* down_found, bool* pressed_found) {
+    *down_found = false;
+    *pressed_found = false;
+    if (elem.keys.empty()) {
+        return false;
+    }
+
+    std::unordered_set<int> expected_vks;
+    for (const String& key : elem.keys) {
+        int vk = 0;
+        if (!shortcut_key_name_to_windows_vk(key, &vk)) {
+            return false;
+        }
+        expected_vks.emplace(vk);
+    }
+
+    static std::unordered_map<String, bool> previous_pressed;
+    if (!Window::GetState().focused) {
+        previous_pressed[elem.name] = false;
+        return true;
+    }
+
+    bool pressed = windows_shortcut_modifier_state_matches(elem.keys) &&
+        windows_shortcut_non_modifier_state_matches(expected_vks);
+    for (const String& key : elem.keys) {
+        int vk = 0;
+        shortcut_key_name_to_windows_vk(key, &vk);
+        pressed &= windows_vk_pressed(vk);
+    }
+
+    const bool previous = previous_pressed[elem.name];
+    previous_pressed[elem.name] = pressed;
+
+    *pressed_found = pressed;
+    *down_found = pressed && !previous;
+    return true;
+}
+#endif
+
 class Shortcut_keys {
 public:
     std::vector<Shortcut_key_elem> shortcut_keys;
@@ -392,6 +530,20 @@ public:
         *shortcut_name_down = SHORTCUT_KEY_UNDEFINED;
         *shortcut_name_pressed = SHORTCUT_KEY_UNDEFINED;
         for (const Shortcut_key_elem &elem: shortcut_keys) {
+#if SIV3D_PLATFORM(WINDOWS)
+            bool windows_down_found = false;
+            bool windows_pressed_found = false;
+            if (check_windows_shortcut_key_state(elem, &windows_down_found, &windows_pressed_found)) {
+                if (windows_pressed_found) {
+                    if (windows_down_found) {
+                        *shortcut_name_down = elem.name;
+                    }
+                    *shortcut_name_pressed = elem.name;
+                    return;
+                }
+                continue;
+            }
+#endif
             if (keys.size() && keys.size() == elem.keys.size()) {
                 bool matched = true;
                 for (const String& key : keys) {

--- a/tools/shortcut_diag/run_shortcut_diag.ps1
+++ b/tools/shortcut_diag/run_shortcut_diag.ps1
@@ -1,0 +1,433 @@
+﻿param(
+    [ValidateSet("Default", "NegativeExtra", "CustomVkPositive")]
+    [string]$Scenario = "Default",
+    [string]$Label = "",
+    [int]$StartupDelaySeconds = 5,
+    [switch]$PromptBeforeKeys,
+    [string]$LogDirectory = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$exePath = Join-Path $repoRoot "bin\Egaroucid.exe"
+if ([string]::IsNullOrWhiteSpace($LogDirectory)) {
+    $LogDirectory = Join-Path $repoRoot "review_packages"
+}
+if ([string]::IsNullOrWhiteSpace($Label)) {
+    $Label = $Scenario.ToLowerInvariant()
+}
+$logPath = Join-Path $LogDirectory ("shortcut_diag_{0}_{1}.log" -f $Label, (Get-Date -Format "yyyyMMdd_HHmmss"))
+
+if (-not (Test-Path $exePath)) {
+    throw "Egaroucid.exe not found: $exePath"
+}
+if (-not (Test-Path $LogDirectory)) {
+    New-Item -ItemType Directory -Path $LogDirectory | Out-Null
+}
+if (Test-Path $logPath) {
+    Remove-Item -LiteralPath $logPath
+}
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class Win32ShortcutDiag {
+    [DllImport("user32.dll")]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetForegroundWindow();
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct INPUT {
+        public uint type;
+        public INPUTUNION U;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct INPUTUNION {
+        [FieldOffset(0)]
+        public MOUSEINPUT mi;
+        [FieldOffset(0)]
+        public KEYBDINPUT ki;
+        [FieldOffset(0)]
+        public HARDWAREINPUT hi;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MOUSEINPUT {
+        public int dx;
+        public int dy;
+        public uint mouseData;
+        public uint dwFlags;
+        public uint time;
+        public UIntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct KEYBDINPUT {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public UIntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct HARDWAREINPUT {
+        public uint uMsg;
+        public ushort wParamL;
+        public ushort wParamH;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    public const uint INPUT_KEYBOARD = 1;
+    public const uint KEYEVENTF_KEYUP = 0x0002;
+
+    public static void KeyDown(ushort vk) {
+        SendKey(vk, 0);
+    }
+
+    public static void KeyUp(ushort vk) {
+        SendKey(vk, KEYEVENTF_KEYUP);
+    }
+
+    private static void SendKey(ushort vk, uint flags) {
+        INPUT[] inputs = new INPUT[1];
+        inputs[0].type = INPUT_KEYBOARD;
+        inputs[0].U.ki.wVk = vk;
+        inputs[0].U.ki.wScan = 0;
+        inputs[0].U.ki.dwFlags = flags;
+        inputs[0].U.ki.time = 0;
+        inputs[0].U.ki.dwExtraInfo = UIntPtr.Zero;
+        uint sent = SendInput(1, inputs, Marshal.SizeOf(typeof(INPUT)));
+        if (sent != 1) {
+            throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+        }
+    }
+}
+"@
+
+function Wait-EgaroucidWindow {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [int]$TimeoutMilliseconds = 10000
+    )
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMilliseconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $Process.Refresh()
+        if ($Process.HasExited) {
+            throw "Egaroucid exited before a main window was created."
+        }
+        if ($Process.MainWindowHandle -ne [IntPtr]::Zero) {
+            return $Process.MainWindowHandle
+        }
+        Start-Sleep -Milliseconds 100
+    }
+
+    throw "Timed out waiting for Egaroucid main window."
+}
+
+function Set-EgaroucidForeground {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [int]$TimeoutMilliseconds = 5000
+    )
+
+    $handle = Wait-EgaroucidWindow -Process $Process
+    [Win32ShortcutDiag]::ShowWindow($handle, 9) | Out-Null
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMilliseconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        [Win32ShortcutDiag]::SetForegroundWindow($handle) | Out-Null
+        Start-Sleep -Milliseconds 150
+        if ([Win32ShortcutDiag]::GetForegroundWindow() -eq $handle) {
+            Start-Sleep -Milliseconds 250
+            return
+        }
+    }
+
+    throw "Timed out waiting for Egaroucid to become the foreground window."
+}
+
+function Get-LogLineCount {
+    if (Test-Path $logPath) {
+        return @(Get-Content -LiteralPath $logPath).Count
+    }
+    return 0
+}
+
+function Get-NewLogLines {
+    param([int]$BeforeCount)
+
+    if (-not (Test-Path $logPath)) {
+        return @()
+    }
+    $allLines = @(Get-Content -LiteralPath $logPath)
+    if ($allLines.Count -le $BeforeCount) {
+        return @()
+    }
+    return $allLines[$BeforeCount..($allLines.Count - 1)]
+}
+
+function Send-ShortcutChord {
+    param([UInt16[]]$Vks)
+
+    foreach ($vk in $Vks) {
+        [Win32ShortcutDiag]::KeyDown($vk)
+        Start-Sleep -Milliseconds 30
+    }
+    Start-Sleep -Milliseconds 120
+    for ($i = $Vks.Count - 1; $i -ge 0; --$i) {
+        [Win32ShortcutDiag]::KeyUp($Vks[$i])
+        Start-Sleep -Milliseconds 30
+    }
+    Start-Sleep -Milliseconds 350
+}
+
+function Invoke-PositiveShortcutTest {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [string]$Name,
+        [UInt16[]]$Vks,
+        [string]$Expected
+    )
+
+    Write-Host ("Sending {0}" -f $Name)
+    Set-EgaroucidForeground -Process $Process -TimeoutMilliseconds 3000
+    $beforeCount = Get-LogLineCount
+    Send-ShortcutChord -Vks $Vks
+    $afterLines = @(Get-NewLogLines -BeforeCount $beforeCount)
+    $matched = $afterLines | Where-Object { $_ -match ("down=" + [regex]::Escape($Expected) + "(\t|$)") } | Select-Object -First 1
+
+    return [pscustomobject]@{
+        Name = $Name
+        Expected = $Expected
+        Passed = [bool]$matched
+        Evidence = $matched
+    }
+}
+
+function Invoke-NegativeShortcutTest {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [string]$Name,
+        [scriptblock]$Send,
+        [string]$Forbidden
+    )
+
+    Write-Host ("Sending negative case {0}" -f $Name)
+    Set-EgaroucidForeground -Process $Process -TimeoutMilliseconds 3000
+    $beforeCount = Get-LogLineCount
+    & $Send
+    $afterLines = @(Get-NewLogLines -BeforeCount $beforeCount)
+    $matched = $afterLines | Where-Object { $_ -match ("down=" + [regex]::Escape($Forbidden) + "(\t|$)") } | Select-Object -First 1
+
+    return [pscustomobject]@{
+        Name = $Name
+        Expected = "not $Forbidden"
+        Passed = -not [bool]$matched
+        Evidence = $matched
+    }
+}
+
+function Write-CustomShortcutConfig {
+    $appDataDir = Join-Path $env:LOCALAPPDATA "Egaroucid"
+    $shortcutConfigPath = Join-Path $appDataDir "shortcut_key.json"
+    if (-not (Test-Path $appDataDir)) {
+        New-Item -ItemType Directory -Path $appDataDir | Out-Null
+    }
+
+    $backupPath = $null
+    if (Test-Path $shortcutConfigPath) {
+        $backupPath = Join-Path $appDataDir ("shortcut_key.json.shortcut_diag_backup_{0}" -f (Get-Date -Format "yyyyMMdd_HHmmss"))
+        Copy-Item -LiteralPath $shortcutConfigPath -Destination $backupPath
+    }
+
+    $json = [ordered]@{
+        analyze = @("F1")
+        ai_put_black = @("Num0")
+    } | ConvertTo-Json
+    Set-Content -LiteralPath $shortcutConfigPath -Value $json -Encoding UTF8
+
+    return [pscustomobject]@{
+        Path = $shortcutConfigPath
+        BackupPath = $backupPath
+    }
+}
+
+function Restore-CustomShortcutConfig {
+    param([object]$ConfigState)
+
+    if ($null -eq $ConfigState) {
+        return
+    }
+    if ($ConfigState.BackupPath -and (Test-Path $ConfigState.BackupPath)) {
+        Move-Item -LiteralPath $ConfigState.BackupPath -Destination $ConfigState.Path -Force
+    } elseif (Test-Path $ConfigState.Path) {
+        Remove-Item -LiteralPath $ConfigState.Path
+    }
+}
+
+$vk = @{
+    Backspace = [UInt16]0x08
+    Tab = [UInt16]0x09
+    Enter = [UInt16]0x0D
+    Shift = [UInt16]0x10
+    Ctrl = [UInt16]0x11
+    Alt = [UInt16]0x12
+    Space = [UInt16]0x20
+    End = [UInt16]0x23
+    Home = [UInt16]0x24
+    Left = [UInt16]0x25
+    Right = [UInt16]0x27
+    Numpad0 = [UInt16]0x60
+    F1 = [UInt16]0x70
+}
+foreach ($code in [char[]]"ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+    $vk[[string]$code] = [UInt16][byte][char]$code
+}
+
+$customConfigState = $null
+if ($Scenario -eq "CustomVkPositive") {
+    $customConfigState = Write-CustomShortcutConfig
+    Write-Host ("Wrote temporary shortcut config: {0}" -f $customConfigState.Path)
+}
+
+$psi = [System.Diagnostics.ProcessStartInfo]::new($exePath)
+$psi.WorkingDirectory = Split-Path -Parent $exePath
+$psi.UseShellExecute = $false
+$psi.Environment["EGAROUCID_SHORTCUT_DIAG_LOG"] = $logPath
+$psi.Environment["EGAROUCID_SHORTCUT_DIAG_ONLY"] = "1"
+
+Write-Host "Starting Egaroucid: $exePath"
+Write-Host "Scenario: $Scenario"
+Write-Host "Diagnostic log: $logPath"
+$proc = [System.Diagnostics.Process]::Start($psi)
+
+try {
+    Start-Sleep -Seconds $StartupDelaySeconds
+    $proc.Refresh()
+    if ($proc.HasExited) {
+        throw "Egaroucid exited before shortcuts could be tested."
+    }
+
+    if ($PromptBeforeKeys) {
+        Read-Host "Switch the input method to the desired state now, then press Enter"
+    }
+
+    Set-EgaroucidForeground -Process $proc
+    Start-Sleep -Seconds 2
+
+    $results = @()
+
+    if ($Scenario -eq "Default") {
+        $tests = @(
+            @{ Name = "Space";      Vks = @($vk.Space);             Expected = "start_game" },
+            @{ Name = "Ctrl+N";     Vks = @($vk.Ctrl, $vk.N);       Expected = "new_game" },
+            @{ Name = "A";          Vks = @($vk.A);                 Expected = "analyze" },
+            @{ Name = "B";          Vks = @($vk.B);                 Expected = "ai_put_black" },
+            @{ Name = "W";          Vks = @($vk.W);                 Expected = "ai_put_white" },
+            @{ Name = "V";          Vks = @($vk.V);                 Expected = "show_disc_hint" },
+            @{ Name = "U";          Vks = @($vk.U);                 Expected = "show_umigame_value" },
+            @{ Name = "D";          Vks = @($vk.D);                 Expected = "show_graph_value" },
+            @{ Name = "S";          Vks = @($vk.S);                 Expected = "show_graph_sum_of_loss" },
+            @{ Name = "P";          Vks = @($vk.P);                 Expected = "show_laser_pointer" },
+            @{ Name = "G";          Vks = @($vk.G);                 Expected = "put_1_move_by_ai" },
+            @{ Name = "Right";      Vks = @($vk.Right);             Expected = "forward" },
+            @{ Name = "Left";       Vks = @($vk.Left);              Expected = "backward" },
+            @{ Name = "Backspace";  Vks = @($vk.Backspace);         Expected = "undo" },
+            @{ Name = "Home";       Vks = @($vk.Home);              Expected = "go_to_first_position" },
+            @{ Name = "End";        Vks = @($vk.End);               Expected = "go_to_last_position" },
+            @{ Name = "Shift+Home"; Vks = @($vk.Shift, $vk.Home);   Expected = "go_to_random_generated_position" },
+            @{ Name = "Ctrl+L";     Vks = @($vk.Ctrl, $vk.L);       Expected = "save_this_branch" },
+            @{ Name = "Ctrl+R";     Vks = @($vk.Ctrl, $vk.R);       Expected = "generate_random_board" },
+            @{ Name = "Q";          Vks = @($vk.Q);                 Expected = "stop_calculating" },
+            @{ Name = "Ctrl+V";     Vks = @($vk.Ctrl, $vk.V);       Expected = "input_from_clipboard" },
+            @{ Name = "Ctrl+E";     Vks = @($vk.Ctrl, $vk.E);       Expected = "edit_board" },
+            @{ Name = "Ctrl+C";     Vks = @($vk.Ctrl, $vk.C);       Expected = "output_transcript" },
+            @{ Name = "Ctrl+S";     Vks = @($vk.Ctrl, $vk.S);       Expected = "screen_shot" }
+        )
+        foreach ($test in $tests) {
+            $results += Invoke-PositiveShortcutTest -Process $proc -Name $test.Name -Vks ([UInt16[]]$test.Vks) -Expected $test.Expected
+        }
+    } elseif ($Scenario -eq "NegativeExtra") {
+        $results += Invoke-NegativeShortcutTest -Process $proc -Name "Ctrl+Shift+N" -Forbidden "new_game" -Send {
+            Send-ShortcutChord -Vks ([UInt16[]]@($vk.Ctrl, $vk.Shift, $vk.N))
+        }
+        $results += Invoke-NegativeShortcutTest -Process $proc -Name "F1 then A" -Forbidden "analyze" -Send {
+            Send-ShortcutChord -Vks ([UInt16[]]@($vk.F1, $vk.A))
+        }
+        $results += Invoke-NegativeShortcutTest -Process $proc -Name "Num0 then A" -Forbidden "analyze" -Send {
+            Send-ShortcutChord -Vks ([UInt16[]]@($vk.Numpad0, $vk.A))
+        }
+        $results += Invoke-NegativeShortcutTest -Process $proc -Name "release F1 while holding A" -Forbidden "analyze" -Send {
+            [Win32ShortcutDiag]::KeyDown($vk.F1)
+            Start-Sleep -Milliseconds 50
+            [Win32ShortcutDiag]::KeyDown($vk.A)
+            Start-Sleep -Milliseconds 200
+            [Win32ShortcutDiag]::KeyUp($vk.F1)
+            Start-Sleep -Milliseconds 300
+            [Win32ShortcutDiag]::KeyUp($vk.A)
+            Start-Sleep -Milliseconds 350
+        }
+    } elseif ($Scenario -eq "CustomVkPositive") {
+        $tests = @(
+            @{ Name = "F1";   Vks = @($vk.F1);      Expected = "analyze" },
+            @{ Name = "Num0"; Vks = @($vk.Numpad0); Expected = "ai_put_black" }
+        )
+        foreach ($test in $tests) {
+            $results += Invoke-PositiveShortcutTest -Process $proc -Name $test.Name -Vks ([UInt16[]]$test.Vks) -Expected $test.Expected
+        }
+    }
+
+    Start-Sleep -Seconds 1
+}
+finally {
+    if ($proc -and -not $proc.HasExited) {
+        $proc.CloseMainWindow() | Out-Null
+        if (-not $proc.WaitForExit(3000)) {
+            $proc.Kill()
+            $proc.WaitForExit()
+        }
+    }
+    Restore-CustomShortcutConfig -ConfigState $customConfigState
+}
+
+if (-not (Test-Path $logPath)) {
+    throw "No diagnostic log was created."
+}
+
+$lines = Get-Content -LiteralPath $logPath
+Write-Host ""
+Write-Host "Diagnostic log tail:"
+$lines | Select-Object -Last 20 | ForEach-Object { Write-Host $_ }
+
+Write-Host ""
+Write-Host "Summary:"
+foreach ($result in $results) {
+    if ($result.Passed) {
+        Write-Host ("PASS {0} -> {1}" -f $result.Name, $result.Expected)
+    } else {
+        Write-Host ("FAIL {0} -> {1}" -f $result.Name, $result.Expected)
+        if ($result.Evidence) {
+            Write-Host ("  Evidence: {0}" -f $result.Evidence)
+        }
+    }
+}
+
+$failed = @($results | Where-Object { -not $_.Passed })
+Write-Host ""
+Write-Host ("Passed {0}/{1}" -f ($results.Count - $failed.Count), $results.Count)
+Write-Host "Log saved to: $logPath"
+if ($failed.Count -gt 0) {
+    exit 1
+}


### PR DESCRIPTION
## Scope

This PR updates Windows shortcut matching so Egaroucid does not depend only on
Siv3D `Input::name()` for shortcut identity. On Windows, shortcut matching now
normalizes keyboard input through virtual-key codes, checks exact key
combinations from one keyboard-state snapshot, and keeps the existing Siv3D
string fallback for unmapped or non-Windows cases.

The fix is intended to cover both default shortcuts and user-customized
shortcuts. Custom shortcuts that can be mapped to Windows virtual-key codes use
the same IME/layout-stable path as the defaults. Unknown custom names still use
the original Siv3D fallback.

## Modified Files

- `src/gui/function/shortcut_key.hpp`
  - Adds Windows virtual-key name normalization for shortcut capture and
    matching.
  - Handles common alphanumeric keys, function keys, numpad keys, navigation
    keys, OEM punctuation keys, Windows keys, IME keys, media/browser keys, and
    `0xNN` virtual-key names.
  - Enforces exact non-modifier matching by scanning the current Windows
    keyboard snapshot instead of checking only a short hard-coded key list.
  - Enforces stricter Ctrl/Shift/Alt family matching, including left/right
    modifier cases.
  - Treats `down` as true only when the exact shortcut is active and an
    expected key became newly pressed.
  - Adds opt-in diagnostic logging controlled by environment variables:
    `EGAROUCID_SHORTCUT_DIAG_LOG` and `EGAROUCID_SHORTCUT_DIAG_ONLY`.
- `tools/shortcut_diag/run_shortcut_diag.ps1`
  - Runs Egaroucid with the diagnostic environment variables enabled.
  - Supports `Default`, `NegativeExtra`, and `CustomVkPositive` scenarios.
  - Writes validation logs to `review_packages` by default so they can be
    attached to review comments without being committed.
- `docs/shortcut_key_ime_validation.md`
  - This validation record.

Local build-only changes in `src/gui/function/const/gui_common.hpp` are not part
of this PR validation scope.

## Validation Environment

- OS: Windows
- Build used for testing: `bin/Egaroucid.exe`
- Build command used locally:
  - `MSBuild.exe Egaroucid.sln /p:Configuration=Release /p:Platform=x64 /m`
- Static check:
  - `git diff --check`
- Available input methods on this machine:
  - Microsoft ENG input method
  - Microsoft Chinese Pinyin input method

Because this machine only has Microsoft ENG and Microsoft Chinese Pinyin
available, additional validation should be performed by other developers with
other IMEs and keyboard layouts, especially Japanese IME and any layout reported
by users in the original issue.

## Latest Test Results

All listed tests passed with the current shortcut-key patch.

| Scenario | Input method state | Result | Attachment log |
| --- | --- | --- | --- |
| Default shortcuts | ENG startup | 24/24 | `review_packages/shortcut_diag_custom_vk_patch_smoke_20260612_194934.log` |
| Extra-key negative cases | ENG startup | 4/4 | `review_packages/shortcut_diag_negative_extra_keys_20260612_195044.log` |
| Extra-key negative cases, committed script self-check | Current active input method | 4/4 | `review_packages/shortcut_diag_script_selfcheck_negative_20260612_200725.log` |
| Custom shortcut VK cases | ENG startup | 2/2 | `review_packages/shortcut_diag_custom_vk_positive_20260612_195216.log` |
| Default shortcuts | Chinese Pinyin startup | 24/24 | `review_packages/shortcut_diag_custom_vk_patch_chinese_all_20260612_195425.log` |
| Default shortcuts | ENG startup, then switched to Chinese Pinyin before testing | 24/24 | `review_packages/shortcut_diag_custom_vk_patch_eng_start_then_chinese_all_20260612_195600.log` |


## Covered Shortcut Cases

The `Default` scenario validates all currently assigned default shortcuts:

- `Space` -> `start_game`
- `Ctrl+N` -> `new_game`
- `A` -> `analyze`
- `B` -> `ai_put_black`
- `W` -> `ai_put_white`
- `V` -> `show_disc_hint`
- `U` -> `show_umigame_value`
- `D` -> `show_graph_value`
- `S` -> `show_graph_sum_of_loss`
- `P` -> `show_laser_pointer`
- `G` -> `put_1_move_by_ai`
- `Right` -> `forward`
- `Left` -> `backward`
- `Backspace` -> `undo`
- `Home` -> `go_to_first_position`
- `End` -> `go_to_last_position`
- `Shift+Home` -> `go_to_random_generated_position`
- `Ctrl+L` -> `save_this_branch`
- `Ctrl+R` -> `generate_random_board`
- `Q` -> `stop_calculating`
- `Ctrl+V` -> `input_from_clipboard`
- `Ctrl+E` -> `edit_board`
- `Ctrl+C` -> `output_transcript`
- `Ctrl+S` -> `screen_shot`

The `NegativeExtra` scenario validates that incomplete exact matching does not
trigger shortcuts:

- `Ctrl+Shift+N` does not trigger `new_game`
- `A+F1` does not trigger `analyze`
- `A+Num0` does not trigger `analyze`
- Releasing `F1` while `A` remains held does not fire `analyze` as a new
  `down` event

The `CustomVkPositive` scenario temporarily writes a local
`shortcut_key.json`, restores it afterward, and validates custom bindings:

- `F1` -> `analyze`
- `Num0` -> `ai_put_black`

## Reproduction Commands

Build Egaroucid first, then run from the repository root:

```powershell
.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario Default -Label eng_default
.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario Default -Label chinese_default -PromptBeforeKeys
.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario Default -Label eng_then_chinese -PromptBeforeKeys
.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario NegativeExtra -Label negative_extra
.\tools\shortcut_diag\run_shortcut_diag.ps1 -Scenario CustomVkPositive -Label custom_vk
```

Use `-PromptBeforeKeys` when the tester needs to switch the active input method
after Egaroucid starts and before automated key input begins.

## Remaining Validation Needed

Other developers should repeat the default, negative, and custom shortcut
scenarios on input methods and keyboard layouts not available on this machine.
In particular:

- Japanese IME
- Non-US keyboard layouts
- Any IME/layout combination reported by users in the original issue
- Additional customized shortcut names if a user report includes a specific
  unsupported key
