### PR TITLE
Update Umigame condition settings

### DIFF
--- a/bin/resources/languages/english.json
+++ b/bin/resources/languages/english.json
@@ -236,6 +236,7 @@
             "disc_value_number": "Number",
             "umigame_value": "Min Memorize Number",
             "depth": "Depth",
+            "integration_error": "Integration Error",
             "opening": "Opening",
             "next_move": "Next Move",
             "next_move_change_view": "Change View",

--- a/bin/resources/languages/japanese.json
+++ b/bin/resources/languages/japanese.json
@@ -238,6 +238,7 @@
             "disc_value_number": "表示個数",
             "umigame_value": "うみがめ数",
             "depth": "深さ",
+            "integration_error": "累積石損",
             "opening": "定石",
             "next_move": "直後の手",
             "next_move_change_view": "表示変更",

--- a/bin/resources/languages/simplified_chinese.json
+++ b/bin/resources/languages/simplified_chinese.json
@@ -238,6 +238,7 @@
             "disc_value_number": "数量",
             "umigame_value": "海龟数量",
             "depth": "深度",
+            "integration_error": "累计子损",
             "opening": "定式",
             "next_move": "落点提示",
             "next_move_change_view": "改变视图",

--- a/bin/resources/languages/traditional_chinese_taiwan.json
+++ b/bin/resources/languages/traditional_chinese_taiwan.json
@@ -236,6 +236,7 @@
             "disc_value_number": "數值",
             "umigame_value": "最小記憶數",
             "depth": "深度",
+            "integration_error": "累計子損",
             "opening": "定石",
             "next_move": "下一步",
             "next_move_change_view": "切換顯示方式",

--- a/src/engine/umigame.hpp
+++ b/src/engine/umigame.hpp
@@ -22,6 +22,80 @@
 */
 constexpr int UMIGAME_UNDEFINED = -1;
 
+/*
+    @brief Recursive search condition for Umigame's value
+
+    The default condition preserves the original best-move-only Umigame search.
+    GUI callers can enable generalized Umigame search by passing a black-score
+    range; that range is applied to every internal child branch.
+*/
+struct Umigame_condition {
+    bool use_score_range;
+    int score_min;
+    int score_max;
+    int integration_error;
+
+    Umigame_condition()
+        : use_score_range(false),
+          score_min(-HW2),
+          score_max(HW2),
+          integration_error(0) {}
+
+    Umigame_condition(int score_min, int score_max)
+        : Umigame_condition(score_min, score_max, 0) {}
+
+    Umigame_condition(int score_min, int score_max, int integration_error)
+        : use_score_range(true),
+          score_min(std::min(score_min, score_max)),
+          score_max(std::max(score_min, score_max)),
+          integration_error(std::max(0, integration_error)) {}
+
+    bool accepts_black_score(int score_black) const {
+        return !use_score_range || (score_min <= score_black && score_black <= score_max);
+    }
+
+    bool uses_original_best_moves() const {
+        return integration_error == 0 &&
+            (!use_score_range || (score_min <= -HW2 && HW2 <= score_max));
+    }
+
+    bool filters_score_range() const {
+        return use_score_range && (score_min > -HW2 || score_max < HW2);
+    }
+};
+
+inline bool operator==(const Umigame_condition& lhs, const Umigame_condition& rhs) {
+    return lhs.use_score_range == rhs.use_score_range &&
+        lhs.score_min == rhs.score_min &&
+        lhs.score_max == rhs.score_max &&
+        lhs.integration_error == rhs.integration_error;
+}
+
+inline bool operator!=(const Umigame_condition& lhs, const Umigame_condition& rhs) {
+    return !(lhs == rhs);
+}
+
+inline int umigame_book_value_to_black_score(int value, int player) {
+    return player == BLACK ? value : -value;
+}
+
+struct Umigame_cache_key {
+    Board board;
+    int remaining_error;
+
+    bool operator==(const Umigame_cache_key& other) const {
+        return board == other.board && remaining_error == other.remaining_error;
+    }
+};
+
+struct Umigame_cache_hash {
+    size_t operator()(const Umigame_cache_key& key) const {
+        size_t seed = Book_hash()(key.board);
+        seed ^= static_cast<size_t>(key.remaining_error + HW2) + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+        return seed;
+    }
+};
+
 
 /*
     @brief Result of umigame value search 
@@ -47,16 +121,44 @@ struct Umigame_result {
 class Umigame {
     private:
         std::mutex mtx;
-        std::unordered_map<Board, Umigame_result, Book_hash> umigame;
+        std::unordered_map<Umigame_cache_key, Umigame_result, Umigame_cache_hash> umigame;
+        int generation;
+        bool cache_context_initialized;
+        int cache_depth;
+        Umigame_condition cache_condition;
 
     public:
-        void calculate(Board *board, int player, int depth) {
-            umigame_search(board, player, depth);
+        Umigame()
+            : generation(0),
+              cache_context_initialized(false),
+              cache_depth(0),
+              cache_condition() {}
+
+        Umigame_result calculate(Board *board, int player, int depth, Umigame_condition condition) {
+            int search_generation = ensure_cache_context(depth, condition);
+            return calculate(board, player, depth, condition, search_generation);
+        }
+
+        Umigame_result calculate(Board *board, int player, int depth, Umigame_condition condition, int search_generation) {
+            return umigame_search(board, player, depth, condition, condition.integration_error, search_generation);
         }
 
         void delete_all() {
             std::lock_guard<std::mutex> lock(mtx);
             umigame.clear();
+            ++generation;
+        }
+
+        int ensure_cache_context(int depth, const Umigame_condition& condition) {
+            std::lock_guard<std::mutex> lock(mtx);
+            if (!cache_context_initialized || cache_depth != depth || cache_condition != condition) {
+                umigame.clear();
+                ++generation;
+                cache_context_initialized = true;
+                cache_depth = depth;
+                cache_condition = condition;
+            }
+            return generation;
         }
 
         /*
@@ -68,7 +170,16 @@ class Umigame {
         Umigame_result get_umigame(Board *b) {
             std::lock_guard<std::mutex> lock(mtx);
             Board unique_board = representative_board(b->copy());
-            return get_oneumigame(unique_board);
+            return get_oneumigame(unique_board, 0);
+        }
+
+        Umigame_result get_umigame(Board *b, int remaining_error, int search_generation) {
+            std::lock_guard<std::mutex> lock(mtx);
+            if (generation != search_generation) {
+                return Umigame_result();
+            }
+            Board unique_board = representative_board(b->copy());
+            return get_oneumigame(unique_board, remaining_error);
         }
 
     private:
@@ -79,7 +190,7 @@ class Umigame {
             @param player                       the player of this board
             @return Umigame's value
         */
-        Umigame_result umigame_search(Board *b, int player, int depth) {
+        Umigame_result umigame_search(Board *b, int player, int depth, const Umigame_condition& condition, int remaining_error, int search_generation) {
             Umigame_result umigame_res;
 			if (!global_searching)
                 return umigame_res;
@@ -88,56 +199,139 @@ class Umigame {
                 umigame_res.w = 1;
                 return umigame_res;
             }
-            umigame_res = get_umigame(b);
+            umigame_res = get_umigame(b, remaining_error, search_generation);
             if (umigame_res.b != UMIGAME_UNDEFINED)
                 return umigame_res;
-            int max_val = -INF;
             if (b->get_legal() == 0ULL) {
                 player ^= 1;
                 b->pass();
             }
             Flip flip;
-            Book_elem book_elem = book.get(b);
-            std::vector<int> best_moves = book.get_all_best_moves(b);
+            std::vector<std::pair<int, int>> candidate_moves = get_candidate_moves(b, player, condition, remaining_error);
             //b->print();
-            if (best_moves.size() == 0) {
+            if (candidate_moves.size() == 0) {
                 umigame_res.b = 1;
                 umigame_res.w = 1;
-				reg(b, umigame_res);
+				reg(b, umigame_res, remaining_error, search_generation);
                 return umigame_res;
             }
             std::vector<Board> boards;
-            for (uint_fast8_t cell: best_moves) {
+            std::vector<int> remaining_errors;
+            for (const std::pair<int, int>& candidate_move: candidate_moves) {
+                int cell = candidate_move.first;
                 calc_flip(&flip, b, cell);
                 boards.emplace_back(b->move_copy(&flip));
+                remaining_errors.emplace_back(candidate_move.second);
             }
             if (player == BLACK) {
                 umigame_res.b = INF;
                 umigame_res.w = 0;
-                for (Board &nnb : boards) {
-                    Umigame_result nres = umigame_search(&nnb, player ^ 1, depth);
+                for (size_t i = 0; i < boards.size(); ++i) {
+                    Umigame_result nres = umigame_search(&boards[i], player ^ 1, depth, condition, remaining_errors[i], search_generation);
                     umigame_res.b = std::min(umigame_res.b, nres.b);
                     umigame_res.w += nres.w;
                 }
             } else {
                 umigame_res.b = 0;
                 umigame_res.w = INF;
-                for (Board &nnb : boards) {
-                    Umigame_result nres = umigame_search(&nnb, player ^ 1, depth);
+                for (size_t i = 0; i < boards.size(); ++i) {
+                    Umigame_result nres = umigame_search(&boards[i], player ^ 1, depth, condition, remaining_errors[i], search_generation);
                     umigame_res.w = std::min(umigame_res.w, nres.w);
                     umigame_res.b += nres.b;
                 }
             }
             if (global_searching) {
-                reg(b, umigame_res);
+                reg(b, umigame_res, remaining_error, search_generation);
             }
             return umigame_res;
         }
 
-        inline void reg(Board *b, Umigame_result val) {
+        inline std::vector<std::pair<int, int>> get_candidate_moves(Board *b, int player, const Umigame_condition& condition, int remaining_error) {
+            std::vector<std::pair<int, int>> policies;
+            if (remaining_error == 0) {
+                for (int policy: book.get_all_best_moves(b)) {
+                    if (!condition.uses_original_best_moves() && condition.filters_score_range()) {
+                        int value;
+                        if (!get_registered_move_value(b, policy, &value) ||
+                            !condition.accepts_black_score(umigame_book_value_to_black_score(value, player))) {
+                            continue;
+                        }
+                    }
+                    policies.emplace_back(policy, remaining_error);
+                }
+                return policies;
+            }
+            std::vector<Book_value> moves = get_registered_moves_with_value(b);
+            int best_value = -INF;
+            for (const Book_value& move: moves) {
+                best_value = std::max(best_value, move.value);
+            }
+            for (const Book_value& move: moves) {
+                int local_loss = best_value - move.value;
+                if (local_loss <= remaining_error &&
+                    condition.accepts_black_score(umigame_book_value_to_black_score(move.value, player))) {
+                    policies.emplace_back(move.policy, remaining_error - local_loss);
+                }
+            }
+            return policies;
+        }
+
+        inline bool get_registered_move_value(Board *b, int policy, int *value) {
+            Flip flip;
+            calc_flip(&flip, b, policy);
+            b->move_board(&flip);
+
+            bool found = false;
+            if (b->is_end()) {
+                if (book.contain(b)) {
+                    *value = -book.get(b).value;
+                    found = true;
+                } else {
+                    b->pass();
+                    if (book.contain(b)) {
+                        *value = book.get(b).value;
+                        found = true;
+                    }
+                    b->pass();
+                }
+            } else if (b->get_legal() == 0ULL) {
+                b->pass();
+                if (book.contain(b)) {
+                    *value = book.get(b).value;
+                    found = true;
+                }
+                b->pass();
+            } else if (book.contain(b)) {
+                *value = -book.get(b).value;
+                found = true;
+            }
+
+            b->undo_board(&flip);
+            return found;
+        }
+
+        inline std::vector<Book_value> get_registered_moves_with_value(Board *b) {
+            std::vector<Book_value> moves;
+            uint64_t legal = b->get_legal();
+            for (uint_fast8_t cell = first_bit(&legal); legal; cell = next_bit(&legal)) {
+                int value;
+                if (get_registered_move_value(b, static_cast<int>(cell), &value)) {
+                    Book_value move;
+                    move.policy = static_cast<int>(cell);
+                    move.value = value;
+                    moves.emplace_back(move);
+                }
+            }
+            return moves;
+        }
+
+        inline void reg(Board *b, Umigame_result val, int remaining_error, int search_generation) {
             Board unique_board = representative_board(b->copy());
             std::lock_guard<std::mutex> lock(mtx);
-            umigame[unique_board] = val;
+            if (generation != search_generation) {
+                return;
+            }
+            umigame[Umigame_cache_key{unique_board, remaining_error}] = val;
         }
 
         /*
@@ -146,19 +340,20 @@ class Umigame {
             @param b                    a board to find
             @return registered umigame's value (if not registered, returns defalut)
         */
-        inline Umigame_result get_oneumigame(Board b) {
+        inline Umigame_result get_oneumigame(Board b, int remaining_error) {
             Umigame_result res;
             res.b = UMIGAME_UNDEFINED;
             res.w = UMIGAME_UNDEFINED;
-            if (umigame.find(b) != umigame.end()) {
-                res = umigame[b];
+            Umigame_cache_key key{b, remaining_error};
+            if (umigame.find(key) != umigame.end()) {
+                res = umigame[key];
             }
             return res;
         }
 
         inline bool contain(Board b) {
             Board unique_board = representative_board(b);
-            return umigame.find(unique_board) != umigame.end();
+            return umigame.find(Umigame_cache_key{unique_board, 0}) != umigame.end();
         }
 };
 
@@ -171,11 +366,11 @@ Umigame umigame;
     @param player                       the player of this board
     @return Umigame's value in Umigame_result structure
 */
-Umigame_result calculate_umigame(Board *b, int player, int depth) {
-    Umigame_result res = umigame.get_umigame(b);
+Umigame_result calculate_umigame(Board *b, int player, int depth, Umigame_condition condition = Umigame_condition()) {
+    int search_generation = umigame.ensure_cache_context(depth, condition);
+    Umigame_result res = umigame.get_umigame(b, condition.integration_error, search_generation);
     if (res.b == UMIGAME_UNDEFINED) {
-        umigame.calculate(b, player, depth);
-        res = umigame.get_umigame(b);
+        res = umigame.calculate(b, player, depth, condition, search_generation);
     }
     return res;
 }

--- a/src/gui/close_scene.hpp
+++ b/src/gui/close_scene.hpp
@@ -109,6 +109,10 @@ void save_settings(Menu_elements menu_elements, Settings settings, Directories d
     setting_json[U"use_book_learn_error_per_move"] = menu_elements.use_book_learn_error_per_move;
     setting_json[U"use_book_learn_error_sum"] = menu_elements.use_book_learn_error_sum;
     setting_json[U"umigame_value_depth"] = menu_elements.umigame_value_depth;
+    setting_json[U"umigame_value_score_slider_version"] = UMIGAME_VALUE_SCORE_SLIDER_VERSION;
+    setting_json[U"umigame_value_score_min"] = menu_elements.umigame_value_score_min;
+    setting_json[U"umigame_value_score_max"] = menu_elements.umigame_value_score_max;
+    setting_json[U"umigame_value_integration_error"] = menu_elements.umigame_value_integration_error;
     setting_json[U"show_graph_value"] = menu_elements.show_graph_value;
     setting_json[U"show_graph_sum_of_loss"] = menu_elements.show_graph_sum_of_loss;
     setting_json[U"show_random_board_graph"] = menu_elements.show_random_board_graph;

--- a/src/gui/function/const/gui_common.hpp
+++ b/src/gui/function/const/gui_common.hpp
@@ -13,6 +13,57 @@
 #include <iostream>
 #include <Siv3D.hpp>
 #include "./../../../engine/engine_all.hpp"
+
+constexpr int UMIGAME_VALUE_SCORE_MIN = 0;
+constexpr int UMIGAME_VALUE_SCORE_MAX = 18;
+constexpr int UMIGAME_VALUE_SCORE_MIN_GAP = 0;
+constexpr int UMIGAME_VALUE_SCORE_SLIDER_VERSION = 2;
+constexpr int UMIGAME_VALUE_INTEGRATION_ERROR_MIN = 0;
+constexpr int UMIGAME_VALUE_INTEGRATION_ERROR_MAX = 21;
+constexpr int UMIGAME_VALUE_INTEGRATION_ERROR_UNLIMITED = UMIGAME_VALUE_INTEGRATION_ERROR_MAX;
+
+inline int umigame_score_slider_to_score(int value) {
+    static constexpr int score_values[UMIGAME_VALUE_SCORE_MAX - UMIGAME_VALUE_SCORE_MIN + 1] = {
+        -64, -8, -7, -6, -5, -4, -3, -2, -1,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 64
+    };
+    value = std::clamp(value, UMIGAME_VALUE_SCORE_MIN, UMIGAME_VALUE_SCORE_MAX);
+    return score_values[value - UMIGAME_VALUE_SCORE_MIN];
+}
+
+inline int migrate_legacy_umigame_score_slider_value(int value) {
+    if (9 <= value && value <= 17) {
+        return value + 1;
+    }
+    return value;
+}
+
+inline int umigame_score_to_slider(int score) {
+    int best_value = UMIGAME_VALUE_SCORE_MIN;
+    int best_error = INF;
+    for (int value = UMIGAME_VALUE_SCORE_MIN; value <= UMIGAME_VALUE_SCORE_MAX; ++value) {
+        const int mapped_score = umigame_score_slider_to_score(value);
+        const int error = std::abs(mapped_score - score);
+        if (error < best_error) {
+            best_error = error;
+            best_value = value;
+        }
+    }
+    return best_value;
+}
+
+inline int normalize_umigame_score_slider_value(int value) {
+    if (value < UMIGAME_VALUE_SCORE_MIN || UMIGAME_VALUE_SCORE_MAX < value) {
+        return umigame_score_to_slider(value);
+    }
+    return std::clamp(value, UMIGAME_VALUE_SCORE_MIN, UMIGAME_VALUE_SCORE_MAX);
+}
+
+inline int umigame_integration_error_slider_to_error(int value) {
+    value = std::clamp(value, UMIGAME_VALUE_INTEGRATION_ERROR_MIN, UMIGAME_VALUE_INTEGRATION_ERROR_MAX);
+    return value == UMIGAME_VALUE_INTEGRATION_ERROR_UNLIMITED ? INF : value;
+}
+
 #include "./../menu.hpp"
 #include "info.hpp"
 #include "url.hpp"
@@ -317,9 +368,7 @@ inline bool last_window_focused = true;
 
 inline void apply_enabled_state(const bool enabled) {
 #if SIV3D_PLATFORM(WINDOWS)
-    if (enabled) {
-        Platform::Windows::TextInput::EnableIME();
-    } else {
+    if (!enabled) {
         Platform::Windows::TextInput::DisableIME();
     }
 #else
@@ -488,6 +537,9 @@ struct Settings {
     bool use_disc_hint;
     bool use_umigame_value;
     int umigame_value_depth;
+    int umigame_value_score_min;
+    int umigame_value_score_max;
+    int umigame_value_integration_error;
     int n_disc_hint;
     bool show_legal;
     bool show_graph;
@@ -658,6 +710,9 @@ struct Menu_elements {
     bool show_hint_level;
     bool use_umigame_value;
     int umigame_value_depth;
+    int umigame_value_score_min;
+    int umigame_value_score_max;
+    int umigame_value_integration_error;
     bool show_legal;
     bool show_graph;
     bool show_opening_on_cell;
@@ -816,6 +871,9 @@ struct Menu_elements {
         show_hint_level = settings->show_hint_level;
         use_umigame_value = settings->use_umigame_value;
         umigame_value_depth = settings->umigame_value_depth;
+        umigame_value_score_min = settings->umigame_value_score_min;
+        umigame_value_score_max = settings->umigame_value_score_max;
+        umigame_value_integration_error = settings->umigame_value_integration_error;
         show_legal = settings->show_legal;
         show_graph = settings->show_graph;
         show_opening_on_cell = settings->show_opening_on_cell;
@@ -1306,10 +1364,17 @@ struct Game_abstract {
     String game_date;      // YYYY-MM-DD format (user-specified game date)
 };
 
+struct Umigame_future_job {
+    int cell;
+    int request_id;
+    std::future<Umigame_result> future;
+};
+
 struct Umigame_status {
     bool umigame_calculating{ false };
     bool umigame_calculated{ false };
-    std::future<Umigame_result> umigame_future[HW2];
+    int request_id{ 0 };
+    std::vector<Umigame_future_job> umigame_future_jobs;
     Umigame_result umigame[HW2];
 };
 

--- a/src/gui/function/display_profile.hpp
+++ b/src/gui/function/display_profile.hpp
@@ -20,6 +20,9 @@ struct Display_profile_values {
     bool show_hint_level{ true };
     bool use_umigame_value{ false };
     int umigame_value_depth{ 60 };
+    int umigame_value_score_min{ UMIGAME_VALUE_SCORE_MIN };
+    int umigame_value_score_max{ UMIGAME_VALUE_SCORE_MAX };
+    int umigame_value_integration_error{ 0 };
     bool show_legal{ true };
     bool show_graph{ true };
     bool show_opening_on_cell{ true };
@@ -69,6 +72,14 @@ inline void ensure_display_settings_dir(const Directories& directories) {
 inline void normalize_display_profile_values(Display_profile_values* values) {
     values->n_disc_hint = std::clamp(values->n_disc_hint, 1, SHOW_ALL_HINT);
     values->umigame_value_depth = std::clamp(values->umigame_value_depth, 1, 60);
+    values->umigame_value_score_min = normalize_umigame_score_slider_value(values->umigame_value_score_min);
+    values->umigame_value_score_max = normalize_umigame_score_slider_value(values->umigame_value_score_max);
+    values->umigame_value_score_min = std::clamp(values->umigame_value_score_min, UMIGAME_VALUE_SCORE_MIN, UMIGAME_VALUE_SCORE_MAX - UMIGAME_VALUE_SCORE_MIN_GAP);
+    values->umigame_value_score_max = std::clamp(values->umigame_value_score_max, UMIGAME_VALUE_SCORE_MIN + UMIGAME_VALUE_SCORE_MIN_GAP, UMIGAME_VALUE_SCORE_MAX);
+    if (values->umigame_value_score_min > values->umigame_value_score_max - UMIGAME_VALUE_SCORE_MIN_GAP) {
+        values->umigame_value_score_min = values->umigame_value_score_max - UMIGAME_VALUE_SCORE_MIN_GAP;
+    }
+    values->umigame_value_integration_error = std::clamp(values->umigame_value_integration_error, UMIGAME_VALUE_INTEGRATION_ERROR_MIN, UMIGAME_VALUE_INTEGRATION_ERROR_MAX);
     values->pv_length = std::clamp(values->pv_length, PV_LENGTH_SETTING_MIN, PV_LENGTH_SETTING_MAX);
 
     if (values->play_ordering_board_format == values->play_ordering_transcript_format) {
@@ -92,6 +103,9 @@ inline Display_profile_values to_display_profile_values(const Settings& settings
     values.show_hint_level = settings.show_hint_level;
     values.use_umigame_value = settings.use_umigame_value;
     values.umigame_value_depth = settings.umigame_value_depth;
+    values.umigame_value_score_min = settings.umigame_value_score_min;
+    values.umigame_value_score_max = settings.umigame_value_score_max;
+    values.umigame_value_integration_error = settings.umigame_value_integration_error;
     values.show_legal = settings.show_legal;
     values.show_graph = settings.show_graph;
     values.show_opening_on_cell = settings.show_opening_on_cell;
@@ -132,6 +146,9 @@ inline Display_profile_values to_display_profile_values(const Menu_elements& men
     values.show_hint_level = menu_elements.show_hint_level;
     values.use_umigame_value = menu_elements.use_umigame_value;
     values.umigame_value_depth = menu_elements.umigame_value_depth;
+    values.umigame_value_score_min = menu_elements.umigame_value_score_min;
+    values.umigame_value_score_max = menu_elements.umigame_value_score_max;
+    values.umigame_value_integration_error = menu_elements.umigame_value_integration_error;
     values.show_legal = menu_elements.show_legal;
     values.show_graph = menu_elements.show_graph;
     values.show_opening_on_cell = menu_elements.show_opening_on_cell;
@@ -173,6 +190,9 @@ inline void apply_display_profile_values(const Display_profile_values& values, S
     settings->show_hint_level = normalized_values.show_hint_level;
     settings->use_umigame_value = normalized_values.use_umigame_value;
     settings->umigame_value_depth = normalized_values.umigame_value_depth;
+    settings->umigame_value_score_min = normalized_values.umigame_value_score_min;
+    settings->umigame_value_score_max = normalized_values.umigame_value_score_max;
+    settings->umigame_value_integration_error = normalized_values.umigame_value_integration_error;
     settings->show_legal = normalized_values.show_legal;
     settings->show_graph = normalized_values.show_graph;
     settings->show_opening_on_cell = normalized_values.show_opening_on_cell;
@@ -212,6 +232,9 @@ inline void apply_display_profile_values(const Display_profile_values& values, M
     menu_elements->show_hint_level = normalized_values.show_hint_level;
     menu_elements->use_umigame_value = normalized_values.use_umigame_value;
     menu_elements->umigame_value_depth = normalized_values.umigame_value_depth;
+    menu_elements->umigame_value_score_min = normalized_values.umigame_value_score_min;
+    menu_elements->umigame_value_score_max = normalized_values.umigame_value_score_max;
+    menu_elements->umigame_value_integration_error = normalized_values.umigame_value_integration_error;
     menu_elements->show_legal = normalized_values.show_legal;
     menu_elements->show_graph = normalized_values.show_graph;
     menu_elements->show_opening_on_cell = normalized_values.show_opening_on_cell;
@@ -276,6 +299,10 @@ inline void export_display_profile_json(JSON& json, const Display_profile_values
     json[U"show_hint_level"] = normalized_values.show_hint_level;
     json[U"use_umigame_value"] = normalized_values.use_umigame_value;
     json[U"umigame_value_depth"] = normalized_values.umigame_value_depth;
+    json[U"umigame_value_score_slider_version"] = UMIGAME_VALUE_SCORE_SLIDER_VERSION;
+    json[U"umigame_value_score_min"] = normalized_values.umigame_value_score_min;
+    json[U"umigame_value_score_max"] = normalized_values.umigame_value_score_max;
+    json[U"umigame_value_integration_error"] = normalized_values.umigame_value_integration_error;
     json[U"show_legal"] = normalized_values.show_legal;
     json[U"show_graph"] = normalized_values.show_graph;
     json[U"show_opening_on_cell"] = normalized_values.show_opening_on_cell;
@@ -318,6 +345,13 @@ inline bool load_display_profile_values(const FilePath& path, Display_profile_va
     import_display_profile_bool(json, U"show_hint_level", &values->show_hint_level);
     import_display_profile_bool(json, U"use_umigame_value", &values->use_umigame_value);
     import_display_profile_int(json, U"umigame_value_depth", &values->umigame_value_depth);
+    import_display_profile_int(json, U"umigame_value_score_min", &values->umigame_value_score_min);
+    import_display_profile_int(json, U"umigame_value_score_max", &values->umigame_value_score_max);
+    if (json[U"umigame_value_score_slider_version"].getType() != JSONValueType::Number) {
+        values->umigame_value_score_min = migrate_legacy_umigame_score_slider_value(values->umigame_value_score_min);
+        values->umigame_value_score_max = migrate_legacy_umigame_score_slider_value(values->umigame_value_score_max);
+    }
+    import_display_profile_int(json, U"umigame_value_integration_error", &values->umigame_value_integration_error);
     import_display_profile_bool(json, U"show_legal", &values->show_legal);
     import_display_profile_bool(json, U"show_graph", &values->show_graph);
     import_display_profile_bool(json, U"show_opening_on_cell", &values->show_opening_on_cell);
@@ -369,6 +403,9 @@ inline bool equals_display_profile_values(const Display_profile_values& lhs, con
     if (lhs.show_hint_level != rhs.show_hint_level) return false;
     if (lhs.use_umigame_value != rhs.use_umigame_value) return false;
     if (lhs.umigame_value_depth != rhs.umigame_value_depth) return false;
+    if (lhs.umigame_value_score_min != rhs.umigame_value_score_min) return false;
+    if (lhs.umigame_value_score_max != rhs.umigame_value_score_max) return false;
+    if (lhs.umigame_value_integration_error != rhs.umigame_value_integration_error) return false;
     if (lhs.show_legal != rhs.show_legal) return false;
     if (lhs.show_graph != rhs.show_graph) return false;
     if (lhs.show_opening_on_cell != rhs.show_opening_on_cell) return false;

--- a/src/gui/function/menu.hpp
+++ b/src/gui/function/menu.hpp
@@ -141,6 +141,18 @@ private:
     // display image on the menu (for language selection)
     bool use_image;
     Texture image;
+    int (*bar_display_mapper)(int);
+
+    String format_bar_value(int value) const {
+        if (bar_display_mapper == nullptr) {
+            return Format(value);
+        }
+        const int display_value = bar_display_mapper(value);
+        if (display_value >= INF) {
+            return U"Inf";
+        }
+        return Format(display_value);
+    }
 
     int cursor_to_bar_value(double cursor_x, bool is_right_elem = false) const {
         if (max_elem == min_elem) {
@@ -243,6 +255,7 @@ public:
         is_clicked = false;
         use_image = false;
         arrow_left = al;
+        bar_display_mapper = nullptr;
     }
 
     void init_bar(String s, int *c, int d, int mn, int mx) {
@@ -261,6 +274,11 @@ public:
         max_elem = mx;
         is_clicked = false;
         use_image = false;
+        bar_display_mapper = nullptr;
+    }
+
+    void set_bar_display_mapper(int (*mapper)(int)) {
+        bar_display_mapper = mapper;
     }
 
     void init_check(String s, bool *c, bool d) {
@@ -543,7 +561,7 @@ public:
             if (mode == MENU_MODE_BAR_CHECK && !(*is_checked)) {
                 font(unchecked_str).draw(font_size, Arg::topRight(bar_sx - menu_child_offset - 4, rect.y + menu_offset_y), menu_font_color);
             } else {
-                font(*bar_elem).draw(font_size, Arg::topRight(bar_sx - menu_child_offset - 4, rect.y + menu_offset_y), menu_font_color);
+                font(format_bar_value(*bar_elem)).draw(font_size, Arg::topRight(bar_sx - menu_child_offset - 4, rect.y + menu_offset_y), menu_font_color);
             }
             if (mode == MENU_MODE_BAR_CHECK && !(*is_checked)) {
                 bar_rect.draw(ColorF(bar_color, 0.5));
@@ -557,7 +575,7 @@ public:
                 bar_circle.draw(bar_circle_color);
             }
         } else if (mode == MENU_MODE_2BARS) {
-            String range_str = Format(*bar_elem1, U"~", *bar_elem2);
+            String range_str = format_bar_value(*bar_elem1) + U"~" + format_bar_value(*bar_elem2);
             font(range_str).draw(font_size, Arg::topRight(bar_sx - menu_child_offset - 4, rect.y + menu_offset_y), menu_font_color);
             Rect left_label(bar_rect.x, bar_rect.y, bar_rect.w / 2, bar_rect.h);
             Rect right_label(bar_rect.x + bar_rect.w / 2, bar_rect.y, bar_rect.w - bar_rect.w / 2, bar_rect.h);
@@ -676,6 +694,7 @@ public:
         children.clear();
         str = U"";
         bar_active_circle = 0;
+        bar_display_mapper = nullptr;
     }
 
     int menu_mode() const {

--- a/src/gui/function/menu_definition.hpp
+++ b/src/gui/function/menu_definition.hpp
@@ -116,6 +116,12 @@ Menu create_menu(Menu_elements* menu_elements, Resources *resources, Font font, 
             side_menu.init_check(language.get("display", "cell", "umigame_value") + get_shortcut_key_info(U"show_umigame_value"), &menu_elements->use_umigame_value, menu_elements->use_umigame_value);
             side_side_menu.init_bar(language.get("display", "cell", "depth"), &menu_elements->umigame_value_depth, menu_elements->umigame_value_depth, 1, 60);
             side_menu.push(side_side_menu);
+            side_side_menu.init_bar(language.get("display", "cell", "integration_error"), &menu_elements->umigame_value_integration_error, menu_elements->umigame_value_integration_error, UMIGAME_VALUE_INTEGRATION_ERROR_MIN, UMIGAME_VALUE_INTEGRATION_ERROR_MAX);
+            side_side_menu.set_bar_display_mapper(umigame_integration_error_slider_to_error);
+            side_menu.push(side_side_menu);
+            side_side_menu.init_2bars(language.get("operation", "generate_random_board", "score_range"), &menu_elements->umigame_value_score_min, &menu_elements->umigame_value_score_max, menu_elements->umigame_value_score_min, menu_elements->umigame_value_score_max, UMIGAME_VALUE_SCORE_MIN, UMIGAME_VALUE_SCORE_MAX, UMIGAME_VALUE_SCORE_MIN_GAP, resources->arrow_left);
+            side_side_menu.set_bar_display_mapper(umigame_score_slider_to_score);
+            side_menu.push(side_side_menu);
             menu_e.push(side_menu);
             side_menu.init_check(language.get("display", "cell", "opening") + get_shortcut_key_info(U"show_opening_on_cell"), &menu_elements->show_opening_on_cell, menu_elements->show_opening_on_cell);
             menu_e.push(side_menu);

--- a/src/gui/main_scene.hpp
+++ b/src/gui/main_scene.hpp
@@ -18,6 +18,7 @@
 #include "screen_shot.hpp"
 
 constexpr double HINT_PRIORITY = 0.49;
+constexpr uint64_t UMIGAME_VALUE_SETTING_DEBOUNCE_MSEC = 350;
 
 bool compare_value_cell(std::pair<int, int>& a, std::pair<int, int>& b) {
     return a.first > b.first;
@@ -30,8 +31,8 @@ bool compare_hint_info(Hint_info& a, Hint_info& b) {
     return a.value > b.value;
 }
 
-Umigame_result get_umigame(Board board, int player, int depth) {
-    return calculate_umigame(&board, player, depth);
+Umigame_result get_umigame(Board board, int player, int depth, Umigame_condition condition) {
+    return calculate_umigame(&board, player, depth, condition);
 }
 
 int get_book_accuracy(Board board) {
@@ -53,7 +54,12 @@ private:
     int taking_screen_shot_state;
     bool pausing_in_pass;
     bool putting_1_move_by_ai;
-    int umigame_value_depth_before;
+    int umigame_value_applied_depth;
+    Umigame_condition umigame_value_applied_condition;
+    int umigame_value_pending_depth;
+    Umigame_condition umigame_value_pending_condition;
+    bool umigame_value_has_pending_setting;
+    uint64_t umigame_value_setting_changed_msec;
     String shortcut_key;
     String shortcut_key_pressed;
     uint64_t turn_timer_start_msec;
@@ -113,7 +119,12 @@ public:
         taking_screen_shot_state = 0;
         pausing_in_pass = false;
         putting_1_move_by_ai = false;
-        umigame_value_depth_before = 0;
+        umigame_value_applied_depth = 0;
+        umigame_value_applied_condition = Umigame_condition();
+        umigame_value_pending_depth = 0;
+        umigame_value_pending_condition = Umigame_condition();
+        umigame_value_has_pending_setting = false;
+        umigame_value_setting_changed_msec = 0;
         shortcut_key = SHORTCUT_KEY_UNDEFINED;
         shortcut_key_pressed = SHORTCUT_KEY_UNDEFINED;
         forced_opening_finished_latched = false;
@@ -385,12 +396,7 @@ public:
 
             // umigame calculating / drawing
             if (getData().menu_elements.use_umigame_value && (!hint_ignore || show_value_ai_turn)) {
-                if (umigame_value_depth_before != getData().menu_elements.umigame_value_depth) {
-                    umigame_status.umigame_calculated = false;
-                    umigame_status.umigame_calculating = false;
-                    umigame.delete_all();
-                    umigame_value_depth_before = getData().menu_elements.umigame_value_depth;
-                }
+                update_umigame_value_settings();
                 if (umigame_status.umigame_calculated) {
                     draw_umigame(legal_ignore);
                 } else {
@@ -606,10 +612,62 @@ private:
     }
 
     void reset_book_additional_features() {
-        umigame_status.umigame_calculated = false;
-        umigame_status.umigame_calculating = false;
+        reset_umigame_calculation_status();
         book_accuracy_status.book_accuracy_calculated = false;
         book_accuracy_status.book_accuracy_calculating = false;
+    }
+
+    void reset_umigame_calculation_status() {
+        umigame_status.umigame_calculated = false;
+        umigame_status.umigame_calculating = false;
+        ++umigame_status.request_id;
+        clear_umigame_values();
+    }
+
+    void clear_umigame_values() {
+        for (int i = 0; i < HW2; ++i) {
+            umigame_status.umigame[i] = Umigame_result();
+        }
+    }
+
+    Umigame_condition get_menu_umigame_condition() {
+        return Umigame_condition(
+            umigame_score_slider_to_score(getData().menu_elements.umigame_value_score_min),
+            umigame_score_slider_to_score(getData().menu_elements.umigame_value_score_max),
+            umigame_integration_error_slider_to_error(getData().menu_elements.umigame_value_integration_error)
+        );
+    }
+
+    void apply_umigame_value_settings(int depth, const Umigame_condition& condition) {
+        reset_umigame_calculation_status();
+        umigame.delete_all();
+        umigame_value_applied_depth = depth;
+        umigame_value_applied_condition = condition;
+        umigame_value_has_pending_setting = false;
+    }
+
+    void update_umigame_value_settings() {
+        const int depth = getData().menu_elements.umigame_value_depth;
+        const Umigame_condition condition = get_menu_umigame_condition();
+        if (umigame_value_applied_depth == 0) {
+            apply_umigame_value_settings(depth, condition);
+            return;
+        }
+        if (umigame_value_applied_depth == depth && umigame_value_applied_condition == condition) {
+            umigame_value_has_pending_setting = false;
+            return;
+        }
+        if (!umigame_value_has_pending_setting ||
+            umigame_value_pending_depth != depth ||
+            umigame_value_pending_condition != condition) {
+            umigame_value_has_pending_setting = true;
+            umigame_value_pending_depth = depth;
+            umigame_value_pending_condition = condition;
+            umigame_value_setting_changed_msec = tim();
+        }
+        if (tim() - umigame_value_setting_changed_msec >= UMIGAME_VALUE_SETTING_DEBOUNCE_MSEC) {
+            apply_umigame_value_settings(umigame_value_pending_depth, umigame_value_pending_condition);
+        }
     }
 
     void reset_random_board_generator() {
@@ -642,11 +700,12 @@ private:
             }
         }
         std::cerr << "terminating umigame value" << std::endl;
-        for (int i = 0; i < HW2; ++i) {
-            if (umigame_status.umigame_future[i].valid()) {
-                umigame_status.umigame_future[i].get();
+        for (Umigame_future_job& job: umigame_status.umigame_future_jobs) {
+            if (job.future.valid()) {
+                job.future.get();
             }
         }
+        umigame_status.umigame_future_jobs.clear();
         std::cerr << "terminating book accuracy" << std::endl;
         for (int i = 0; i < HW2; ++i) {
             if (book_accuracy_status.book_accuracy_future[i].valid()) {
@@ -2622,6 +2681,25 @@ private:
             getData().graph_resources.branch == GRAPH_MODE_NORMAL;
     }
 
+    bool is_umigame_value_displayed(Board board, int player, const Umigame_condition& condition) {
+        if (!book.contain(board)) {
+            return false;
+        }
+        Book_elem elem = book.get(board);
+        return condition.accepts_black_score(umigame_book_value_to_black_score(elem.value, player));
+    }
+
+    void add_umigame_job_if_displayed(int cell, Board board, int player, int request_id, const Umigame_condition& condition) {
+        if (!is_umigame_value_displayed(board, player, condition)) {
+            return;
+        }
+        add_umigame_future_job(
+            cell,
+            request_id,
+            std::async(std::launch::async, get_umigame, board, player, umigame_value_applied_depth, condition)
+        );
+    }
+
     void calculate_umigame() {
         if (!changing_scene) {
             uint64_t legal = getData().history_elem.board.get_legal();
@@ -2629,18 +2707,24 @@ private:
                 if (!global_searching) {
                     return;
                 }
+                if (!book.contain(getData().history_elem.board)) {
+                    umigame_status.umigame_calculated = true;
+                    return;
+                }
                 Board board = getData().history_elem.board;
                 int n_player = getData().history_elem.player ^ 1;
+                const int request_id = umigame_status.request_id;
+                const Umigame_condition condition = umigame_value_applied_condition;
                 Flip flip;
                 for (uint_fast8_t cell = first_bit(&legal); legal; cell = next_bit(&legal)) {
                     calc_flip(&flip, &board, cell);
                     board.move_board(&flip);
                         if (board.get_legal() == 0ULL) {
                             board.pass();
-                                umigame_status.umigame_future[cell] = std::async(std::launch::async, get_umigame, board, n_player ^ 1, getData().menu_elements.umigame_value_depth);
+                                add_umigame_job_if_displayed(cell, board, n_player ^ 1, request_id, condition);
                             board.pass();
                         } else {
-                            umigame_status.umigame_future[cell] = std::async(std::launch::async, get_umigame, board, n_player, getData().menu_elements.umigame_value_depth);
+                            add_umigame_job_if_displayed(cell, board, n_player, request_id, condition);
                         }
                     board.undo_board(&flip);
                 }
@@ -2648,17 +2732,8 @@ private:
                 std::cerr << "start umigame calculation" << std::endl;
             }
             else {
-                bool all_done = true;
-                for (uint_fast8_t cell = first_bit(&legal); legal; cell = next_bit(&legal)) {
-                    if (umigame_status.umigame_future[cell].valid()) {
-                        if (umigame_status.umigame_future[cell].wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-                            umigame_status.umigame[cell] = umigame_status.umigame_future[cell].get();
-                        } else {
-                            all_done = false;
-                        }
-                    }
-                }
-                if (all_done) {
+                const int future_update_status = update_umigame_future_jobs();
+                if (future_update_status == UMIGAME_FUTURE_UPDATE_DONE) {
                     umigame_status.umigame_calculating = false;
                     umigame_status.umigame_calculated = !(umigame_calculation_interrupted && global_searching);
                     if (global_searching) {
@@ -2668,6 +2743,39 @@ private:
                 }
             }
         }
+    }
+
+    static constexpr int UMIGAME_FUTURE_UPDATE_WAITING = 0;
+    static constexpr int UMIGAME_FUTURE_UPDATE_DONE = 1;
+
+    void add_umigame_future_job(int cell, int request_id, std::future<Umigame_result> future) {
+        Umigame_future_job job;
+        job.cell = cell;
+        job.request_id = request_id;
+        job.future = std::move(future);
+        umigame_status.umigame_future_jobs.emplace_back(std::move(job));
+    }
+
+    int update_umigame_future_jobs() {
+        bool all_current_jobs_done = true;
+        const int current_request_id = umigame_status.request_id;
+        for (auto it = umigame_status.umigame_future_jobs.begin(); it != umigame_status.umigame_future_jobs.end();) {
+            if (!it->future.valid()) {
+                it = umigame_status.umigame_future_jobs.erase(it);
+            } else if (it->future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+                Umigame_result result = it->future.get();
+                if (it->request_id == current_request_id) {
+                    umigame_status.umigame[it->cell] = result;
+                }
+                it = umigame_status.umigame_future_jobs.erase(it);
+            } else {
+                if (it->request_id == current_request_id) {
+                    all_current_jobs_done = false;
+                }
+                ++it;
+            }
+        }
+        return all_current_jobs_done ? UMIGAME_FUTURE_UPDATE_DONE : UMIGAME_FUTURE_UPDATE_WAITING;
     }
 
     void draw_umigame(uint64_t legal_ignore) {

--- a/src/gui/silent_load_scene.hpp
+++ b/src/gui/silent_load_scene.hpp
@@ -83,6 +83,9 @@ void init_default_settings(const Directories* directories, const Resources* reso
     settings->use_book_learn_error_per_move = true;
     settings->use_book_learn_error_sum = true;
     settings->umigame_value_depth = 60;
+    settings->umigame_value_score_min = UMIGAME_VALUE_SCORE_MIN;
+    settings->umigame_value_score_max = UMIGAME_VALUE_SCORE_MAX;
+    settings->umigame_value_integration_error = 0;
     settings->show_graph_value = true;
     settings->show_graph_sum_of_loss = false;
     settings->show_random_board_graph = false;
@@ -451,6 +454,9 @@ void init_settings(const Directories* directories, const Resources* resources, S
         if (init_settings_import_int(setting_json, U"umigame_value_depth", &settings->umigame_value_depth) != ERR_OK) {
             std::cerr << "err34" << std::endl;
         }
+        init_settings_import_int(setting_json, U"umigame_value_score_min", &settings->umigame_value_score_min);
+        init_settings_import_int(setting_json, U"umigame_value_score_max", &settings->umigame_value_score_max);
+        init_settings_import_int(setting_json, U"umigame_value_integration_error", &settings->umigame_value_integration_error);
         if (init_settings_import_bool(setting_json, U"show_graph_value", &settings->show_graph_value) != ERR_OK) {
             std::cerr << "err35" << std::endl;
         }
@@ -568,6 +574,18 @@ void init_settings(const Directories* directories, const Resources* resources, S
     settings->othello_quest_mode = std::clamp(settings->othello_quest_mode, 0, 2);
     settings->auto_save_ai_profile_mode = std::clamp(settings->auto_save_ai_profile_mode, PROFILE_AUTO_SAVE_MODE_OVERWRITE, PROFILE_AUTO_SAVE_MODE_NEW);
     settings->auto_save_display_profile_mode = std::clamp(settings->auto_save_display_profile_mode, PROFILE_AUTO_SAVE_MODE_OVERWRITE, PROFILE_AUTO_SAVE_MODE_NEW);
+    if (setting_json[U"umigame_value_score_slider_version"].getType() != JSONValueType::Number) {
+        settings->umigame_value_score_min = migrate_legacy_umigame_score_slider_value(settings->umigame_value_score_min);
+        settings->umigame_value_score_max = migrate_legacy_umigame_score_slider_value(settings->umigame_value_score_max);
+    }
+    settings->umigame_value_score_min = normalize_umigame_score_slider_value(settings->umigame_value_score_min);
+    settings->umigame_value_score_max = normalize_umigame_score_slider_value(settings->umigame_value_score_max);
+    settings->umigame_value_score_min = std::clamp(settings->umigame_value_score_min, UMIGAME_VALUE_SCORE_MIN, UMIGAME_VALUE_SCORE_MAX - UMIGAME_VALUE_SCORE_MIN_GAP);
+    settings->umigame_value_score_max = std::clamp(settings->umigame_value_score_max, UMIGAME_VALUE_SCORE_MIN + UMIGAME_VALUE_SCORE_MIN_GAP, UMIGAME_VALUE_SCORE_MAX);
+    if (settings->umigame_value_score_min > settings->umigame_value_score_max - UMIGAME_VALUE_SCORE_MIN_GAP) {
+        settings->umigame_value_score_min = settings->umigame_value_score_max - UMIGAME_VALUE_SCORE_MIN_GAP;
+    }
+    settings->umigame_value_integration_error = std::clamp(settings->umigame_value_integration_error, UMIGAME_VALUE_INTEGRATION_ERROR_MIN, UMIGAME_VALUE_INTEGRATION_ERROR_MAX);
 
     // Keep compatibility with legacy scalar settings when profiles or curves are absent.
     sync_ai_loss_curves_from_scalar(settings);

--- a/src/tools/release_script/format_files/0_common_files/languages/english.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/english.json
@@ -236,6 +236,7 @@
             "disc_value_number": "Number",
             "umigame_value": "Min Memorize Number",
             "depth": "Depth",
+            "integration_error": "Integration Error",
             "opening": "Opening",
             "next_move": "Next Move",
             "next_move_change_view": "Change View",

--- a/src/tools/release_script/format_files/0_common_files/languages/japanese.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/japanese.json
@@ -238,6 +238,7 @@
             "disc_value_number": "表示個数",
             "umigame_value": "うみがめ数",
             "depth": "深さ",
+            "integration_error": "累積石損",
             "opening": "定石",
             "next_move": "直後の手",
             "next_move_change_view": "表示変更",

--- a/src/tools/release_script/format_files/0_common_files/languages/simplified_chinese.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/simplified_chinese.json
@@ -238,6 +238,7 @@
             "disc_value_number": "数量",
             "umigame_value": "海龟数量",
             "depth": "深度",
+            "integration_error": "累计子损",
             "opening": "定式",
             "next_move": "落点提示",
             "next_move_change_view": "改变视图",

--- a/src/tools/release_script/format_files/0_common_files/languages/traditional_chinese_taiwan.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/traditional_chinese_taiwan.json
@@ -236,6 +236,7 @@
             "disc_value_number": "數值",
             "umigame_value": "最小記憶數",
             "depth": "深度",
+            "integration_error": "累計子損",
             "opening": "定石",
             "next_move": "下一步",
             "next_move_change_view": "切換顯示方式",

--- a/src/tools/umigame_filter_semantics/UmigameRegression.vcxproj
+++ b/src/tools/umigame_filter_semantics/UmigameRegression.vcxproj
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Generic|x64">
+      <Configuration>Generic</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="umigame_regression.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{0A06ECA8-7796-4F60-8A47-CA991F965734}</ProjectGuid>
+    <RootNamespace>UmigameRegression</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Generic|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Generic|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Generic|x64'">
+    <OutDir>..\..\..\bin\build_verify\umigame_regression\</OutDir>
+    <IntDir>..\..\..\bin\build_verify\umigame_regression\obj\</IntDir>
+    <TargetName>umigame_regression</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Generic|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalOptions>/D "HAS_NO_AVX2" %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/tools/umigame_filter_semantics/check_umigame_filters.py
+++ b/src/tools/umigame_filter_semantics/check_umigame_filters.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Check the lightweight Umigame score-range and integration-error contracts.
+
+This intentionally does not parse real .egbk3 book files. It verifies the
+source-level wiring for the GUI settings and runs an independent small-tree
+model for recursive black-perspective score-range filtering with cumulative
+local-loss pruning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+BLACK = 0
+WHITE = 1
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@dataclass(frozen=True)
+class Result:
+    b: int
+    w: int
+
+
+@dataclass(frozen=True)
+class Edge:
+    black_score: int
+    child: str
+
+
+@dataclass(frozen=True)
+class Node:
+    player: int
+    edges: tuple[Edge, ...] = ()
+    terminal: Result | None = None
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def require_contains(path: Path, needle: str) -> None:
+    text = read(path)
+    if needle not in text:
+        raise AssertionError(f"{path.relative_to(REPO_ROOT)} does not contain expected text: {needle}")
+
+
+def require_absent(path: Path, needle: str) -> None:
+    text = read(path)
+    if needle in text:
+        raise AssertionError(f"{path.relative_to(REPO_ROOT)} still contains removed text: {needle}")
+
+
+def require_order(path: Path, needles: tuple[str, ...]) -> None:
+    text = read(path)
+    pos = -1
+    for needle in needles:
+        next_pos = text.find(needle, pos + 1)
+        if next_pos == -1:
+            raise AssertionError(f"{path.relative_to(REPO_ROOT)} is missing expected ordered text: {needle}")
+        pos = next_pos
+
+
+def check_source_contracts() -> None:
+    gui_common = REPO_ROOT / "src/gui/function/const/gui_common.hpp"
+    menu_definition = REPO_ROOT / "src/gui/function/menu_definition.hpp"
+    menu = REPO_ROOT / "src/gui/function/menu.hpp"
+    umigame = REPO_ROOT / "src/engine/umigame.hpp"
+    main_scene = REPO_ROOT / "src/gui/main_scene.hpp"
+    regression_runner = REPO_ROOT / "src/tools/umigame_filter_semantics/run_umigame_regression.py"
+    regression_verifier = REPO_ROOT / "src/tools/umigame_filter_semantics/umigame_regression.cpp"
+
+    require_contains(gui_common, "int umigame_value_score_min;")
+    require_contains(gui_common, "int umigame_value_score_max;")
+    require_contains(gui_common, "int umigame_value_integration_error;")
+    require_contains(menu_definition, "init_2bars(language.get(\"operation\", \"generate_random_board\", \"score_range\")")
+    require_contains(menu_definition, "&menu_elements->umigame_value_score_min")
+    require_contains(menu_definition, "&menu_elements->umigame_value_score_max")
+    require_contains(menu_definition, "language.get(\"display\", \"cell\", \"integration_error\")")
+    require_absent(menu_definition, "umigame_value_apply_setting")
+
+    require_contains(menu, "String range_str = format_bar_value(*bar_elem1) + U\"~\" + format_bar_value(*bar_elem2);")
+    require_absent(menu, "init_2bars_player_loss")
+
+    require_contains(umigame, "Umigame_condition(int score_min, int score_max)")
+    require_contains(umigame, "Umigame_condition(int score_min, int score_max, int integration_error)")
+    require_contains(umigame, "struct Umigame_cache_key")
+    require_contains(umigame, "int remaining_error;")
+    require_contains(umigame, "std::vector<Book_value> moves = get_registered_moves_with_value(b);")
+    require_contains(umigame, "inline bool get_registered_move_value(Board *b, int policy, int *value)")
+    require_contains(umigame, "int local_loss = best_value - move.value;")
+    require_contains(umigame, "condition.accepts_black_score(umigame_book_value_to_black_score(move.value, player))")
+    require_contains(umigame, "condition.uses_original_best_moves()")
+    require_absent(umigame, "max_move_loss")
+    require_absent(umigame, "get_all_moves_within_child_loss")
+
+    require_contains(main_scene, "UMIGAME_VALUE_SETTING_DEBOUNCE_MSEC")
+    require_contains(main_scene, "void update_umigame_value_settings()")
+    require_contains(main_scene, "void add_umigame_job_if_displayed(int cell, Board board, int player, int request_id, const Umigame_condition& condition)")
+    require_order(
+        main_scene,
+        (
+            "if (!book.contain(board))",
+            "condition.accepts_black_score(umigame_book_value_to_black_score(elem.value, player))",
+        ),
+    )
+    require_absent(main_scene, "umigame_value_apply_setting")
+
+    require_contains(regression_runner, 'DEFAULT_BOOK = REPO_ROOT / "bin" / "document" / "book.egbk3"')
+    require_contains(regression_verifier, 'constexpr const char* DEFAULT_BOOK_FILE = "document/book.egbk3";')
+
+
+def mover_value(edge: Edge, player: int) -> int:
+    return edge.black_score if player == BLACK else -edge.black_score
+
+
+def brute_force(tree: dict[str, Node], node_id: str, score_min: int, score_max: int, remaining_error: int) -> Result:
+    node = tree[node_id]
+    if node.terminal is not None:
+        return node.terminal
+    if not node.edges:
+        return Result(1, 1)
+
+    best = max(mover_value(edge, node.player) for edge in node.edges)
+    kept = [
+        (edge, remaining_error - (best - mover_value(edge, node.player)))
+        for edge in node.edges
+        if score_min <= edge.black_score <= score_max and best - mover_value(edge, node.player) <= remaining_error
+    ]
+    if not kept:
+        return Result(1, 1)
+
+    child_results = [
+        brute_force(tree, edge.child, score_min, score_max, child_remaining_error)
+        for edge, child_remaining_error in kept
+    ]
+    if node.player == BLACK:
+        return Result(min(result.b for result in child_results), sum(result.w for result in child_results))
+    return Result(sum(result.b for result in child_results), min(result.w for result in child_results))
+
+
+def is_displayed(candidate_in_book: bool, score_black: int, score_min: int, score_max: int) -> bool:
+    return candidate_in_book and score_min <= score_black <= score_max
+
+
+def check_independent_model() -> None:
+    tree = {
+        "root": Node(BLACK, (Edge(8, "white"), Edge(4, "top_loss"))),
+        "white": Node(WHITE, (Edge(-3, "d"), Edge(3, "e"), Edge(9, "f"))),
+        "top_loss": Node(WHITE, terminal=Result(2, 30)),
+        "d": Node(BLACK, terminal=Result(5, 7)),
+        "e": Node(BLACK, terminal=Result(11, 13)),
+        "f": Node(BLACK, terminal=Result(17, 19)),
+    }
+
+    # Full range with Integration Error = 0 keeps only local best moves, so it
+    # preserves original Umigame branch selection.
+    assert brute_force(tree, "root", -64, 64, 0) == Result(5, 7)
+
+    # Range filtering is recursive. Here the best white reply has black score
+    # -3, so range 0..10 prunes it. With Integration Error = 0 the non-best
+    # in-range white replies are still pruned by local loss.
+    assert brute_force(tree, "root", 0, 10, 0) == Result(1, 1)
+
+    # Widening the integration budget admits the in-range white reply with
+    # local loss 6.
+    assert brute_force(tree, "root", 0, 10, 6) == Result(2, 43)
+
+    assert is_displayed(candidate_in_book=True, score_black=3, score_min=0, score_max=6)
+    assert not is_displayed(candidate_in_book=True, score_black=8, score_min=0, score_max=6)
+    assert not is_displayed(candidate_in_book=False, score_black=3, score_min=0, score_max=6)
+
+
+def main() -> None:
+    check_source_contracts()
+    check_independent_model()
+    print("Umigame score-range semantics checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/umigame_filter_semantics/run_umigame_regression.py
+++ b/src/tools/umigame_filter_semantics/run_umigame_regression.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Build and run the bounded real-book Umigame regression verifier.
+
+Defaults are intentionally finite:
+- check at most 100000 reachable book nodes;
+- stop after the first 10 mismatches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TOOL_DIR = Path(__file__).resolve().parent
+PROJECT = TOOL_DIR / "UmigameRegression.vcxproj"
+RUN_DIR = REPO_ROOT / "bin" / "build_verify" / "umigame_regression"
+EXE = RUN_DIR / "umigame_regression.exe"
+DEFAULT_BOOK = REPO_ROOT / "bin" / "document" / "book.egbk3"
+POLL_INTERVAL_SECONDS = 2
+PROGRESS_INTERVAL_SECONDS = 30
+
+
+@dataclass
+class ShardProcess:
+    shard: int
+    process: subprocess.Popen[str]
+    log_path: Path
+    log_file: object
+
+    def close_log(self) -> None:
+        self.log_file.close()
+
+
+def find_msbuild() -> str:
+    candidates = [
+        Path(r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe"),
+        Path(r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe"),
+        Path(r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe"),
+        Path(r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe"),
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return "MSBuild"
+
+
+def run(cmd: list[str], cwd: Path) -> None:
+    print("+ " + " ".join(cmd), flush=True)
+    completed = subprocess.run(cmd, cwd=cwd)
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+
+
+def terminate_running(processes: list[ShardProcess]) -> None:
+    for shard_proc in processes:
+        if shard_proc.process.poll() is None:
+            shard_proc.process.terminate()
+    for shard_proc in processes:
+        if shard_proc.process.poll() is None:
+            try:
+                shard_proc.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                shard_proc.process.kill()
+                shard_proc.process.wait()
+
+
+def print_shard_log(log_path: Path) -> None:
+    print(log_path.read_text(encoding="utf-8", errors="replace"), flush=True)
+
+
+def run_parallel_shards(base_cmd: list[str], shard_count: int) -> None:
+    RUN_DIR.mkdir(parents=True, exist_ok=True)
+
+    processes: list[ShardProcess] = []
+    for shard in range(shard_count):
+        cmd = base_cmd + [
+            "--shard-index",
+            str(shard),
+            "--shard-count",
+            str(shard_count),
+        ]
+        print("+ " + " ".join(cmd), flush=True)
+        log_path = RUN_DIR / f"shard_{shard:02d}.log"
+        log_file = log_path.open("w", encoding="utf-8")
+        process = subprocess.Popen(
+            cmd,
+            cwd=REPO_ROOT / "bin",
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        processes.append(ShardProcess(shard, process, log_path, log_file))
+
+    failed = False
+    next_progress = time.monotonic() + PROGRESS_INTERVAL_SECONDS
+    try:
+        while processes:
+            time.sleep(POLL_INTERVAL_SECONDS)
+            now = time.monotonic()
+            if now >= next_progress:
+                running = ", ".join(f"{shard_proc.shard:02d}" for shard_proc in processes)
+                print(f"still running shards: {running}", flush=True)
+                next_progress = now + PROGRESS_INTERVAL_SECONDS
+
+            still_running: list[ShardProcess] = []
+            for shard_proc in processes:
+                code = shard_proc.process.poll()
+                if code is None:
+                    still_running.append(shard_proc)
+                    continue
+
+                shard_proc.close_log()
+                print(f"shard {shard_proc.shard} finished with code {code}; log={shard_proc.log_path}", flush=True)
+                if code != 0:
+                    failed = True
+                    print_shard_log(shard_proc.log_path)
+                    terminate_running(still_running)
+                    break
+
+            if failed:
+                break
+            processes = still_running
+    finally:
+        terminate_running(processes)
+        for shard_proc in processes:
+            if not shard_proc.log_file.closed:
+                shard_proc.close_log()
+
+    if failed:
+        raise SystemExit(1)
+
+    for shard in range(shard_count):
+        print_shard_log(RUN_DIR / f"shard_{shard:02d}.log")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--book", default=str(DEFAULT_BOOK), help="book file to test")
+    parser.add_argument("--depths", default="8,12,20,60", help="comma-separated Umigame depths")
+    parser.add_argument("--ranges", default="-64:64,0:6,3:5,-6:0", help="comma-separated black-score ranges min:max")
+    parser.add_argument("--integration-errors", default="0,2,6", help="comma-separated cumulative local-loss budgets")
+    parser.add_argument("--node-limit", type=int, default=100000)
+    parser.add_argument("--fail-limit", type=int, default=10)
+    parser.add_argument("--threads", type=int, default=1)
+    parser.add_argument("--parallel-shards", type=int, default=1)
+    parser.add_argument("--no-build", action="store_true")
+    args = parser.parse_args()
+
+    if not args.no_build:
+        run(
+            [
+                find_msbuild(),
+                str(PROJECT),
+                "/m",
+                "/p:Configuration=Generic",
+                "/p:Platform=x64",
+                "/v:minimal",
+            ],
+            REPO_ROOT,
+        )
+
+    if not EXE.exists():
+        raise SystemExit(f"verifier executable not found: {EXE}")
+
+    base_cmd = [
+        str(EXE),
+        "--book",
+        str(Path(args.book)),
+        "--depths",
+        args.depths,
+        "--ranges",
+        args.ranges,
+        "--integration-errors",
+        args.integration_errors,
+        "--node-limit",
+        str(args.node_limit),
+        "--fail-limit",
+        str(args.fail_limit),
+        "--threads",
+        str(args.threads),
+    ]
+
+    if args.parallel_shards <= 1:
+        run(base_cmd, REPO_ROOT / "bin")
+        return
+
+    run_parallel_shards(base_cmd, args.parallel_shards)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/umigame_filter_semantics/umigame_regression.cpp
+++ b/src/tools/umigame_filter_semantics/umigame_regression.cpp
@@ -1,0 +1,714 @@
+/*
+    Bounded real-book regression verifier for generalized Umigame conditions.
+
+    The verifier loads a real Egaroucid book, walks book-reachable positions
+    from the initial board, and compares calculate_umigame() with an independent
+    oracle that applies a black-perspective score range and cumulative local
+    loss budget recursively at every internal node.
+*/
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "../../engine/engine_all.hpp"
+
+namespace {
+
+constexpr const char* DEFAULT_BOOK_FILE = "document/book.egbk3";
+constexpr const char* DEFAULT_DEPTHS = "8,12,20,60";
+constexpr const char* DEFAULT_RANGES = "-64:64,0:6,3:5,-6:0";
+constexpr const char* DEFAULT_INTEGRATION_ERRORS = "0,2,6";
+constexpr int DEFAULT_NODE_LIMIT = 100000;
+constexpr int DEFAULT_FAIL_LIMIT = 10;
+
+struct Score_range {
+    int score_min;
+    int score_max;
+    std::string label;
+};
+
+struct Search_case {
+    int depth;
+    Score_range range;
+    int integration_error;
+};
+
+struct Candidate {
+    int policy;
+    int score_black;
+    Board child;
+    int child_player;
+};
+
+struct Position {
+    Board board;
+    int player;
+    std::string transcript;
+};
+
+struct Failure {
+    std::string kind;
+    std::string transcript;
+    std::string move;
+    std::string board;
+    std::string detail;
+    int player;
+    Search_case search_case;
+    Umigame_result expected;
+    Umigame_result actual;
+};
+
+struct Board_hash {
+    size_t operator()(const Board& board) const {
+        return Book_hash()(board);
+    }
+};
+
+struct Counters {
+    int64_t visited_nodes = 0;
+    int64_t checked_nodes = 0;
+    int64_t checked_node_cases = 0;
+    int64_t checked_moves = 0;
+    int64_t shown_by_score_range = 0;
+    int64_t hidden_by_score_range = 0;
+    int64_t hidden_out_of_book = 0;
+};
+
+void hash_combine(size_t* seed, size_t value) {
+    *seed ^= value + 0x9e3779b97f4a7c15ULL + (*seed << 6) + (*seed >> 2);
+}
+
+std::string player_to_string(int player) {
+    return player == BLACK ? "BLACK" : "WHITE";
+}
+
+std::string result_to_string(const Umigame_result& result) {
+    return "B" + std::to_string(result.b) + " W" + std::to_string(result.w);
+}
+
+Umigame_result make_result(int b, int w) {
+    Umigame_result result;
+    result.b = b;
+    result.w = w;
+    return result;
+}
+
+bool same_result(const Umigame_result& lhs, const Umigame_result& rhs) {
+    return lhs.b == rhs.b && lhs.w == rhs.w;
+}
+
+std::vector<std::string> split_commas(const std::string& text) {
+    std::vector<std::string> items;
+    std::stringstream stream(text);
+    std::string item;
+    while (std::getline(stream, item, ',')) {
+        if (!item.empty()) {
+            items.emplace_back(item);
+        }
+    }
+    return items;
+}
+
+std::vector<int> parse_int_list(const std::string& text) {
+    std::vector<int> values;
+    for (const std::string& item: split_commas(text)) {
+        values.emplace_back(std::stoi(item));
+    }
+    if (values.empty()) {
+        throw std::runtime_error("integer list must not be empty");
+    }
+    return values;
+}
+
+std::vector<Score_range> parse_score_ranges(const std::string& text) {
+    std::vector<Score_range> ranges;
+    for (const std::string& item: split_commas(text)) {
+        size_t sep = item.find(':');
+        if (sep == std::string::npos) {
+            throw std::runtime_error("score range must be min:max, got " + item);
+        }
+
+        int score_min = std::stoi(item.substr(0, sep));
+        int score_max = std::stoi(item.substr(sep + 1));
+        if (score_min > score_max) {
+            std::swap(score_min, score_max);
+        }
+        ranges.push_back(Score_range{
+            score_min,
+            score_max,
+            std::to_string(score_min) + "_" + std::to_string(score_max),
+        });
+    }
+    if (ranges.empty()) {
+        throw std::runtime_error("score range list must not be empty");
+    }
+    return ranges;
+}
+
+struct Options {
+    std::string book_file = DEFAULT_BOOK_FILE;
+    std::vector<int> depths = parse_int_list(DEFAULT_DEPTHS);
+    std::vector<Score_range> ranges = parse_score_ranges(DEFAULT_RANGES);
+    std::vector<int> integration_errors = parse_int_list(DEFAULT_INTEGRATION_ERRORS);
+    int node_limit = DEFAULT_NODE_LIMIT;
+    int fail_limit = DEFAULT_FAIL_LIMIT;
+    int threads = 1;
+    int shard_index = 0;
+    int shard_count = 1;
+};
+
+void require_positive(const char* name, int value) {
+    if (value <= 0) {
+        throw std::runtime_error(std::string(name) + " must be positive");
+    }
+}
+
+void validate_positive_list(const char* name, const std::vector<int>& values) {
+    for (int value: values) {
+        if (value <= 0) {
+            throw std::runtime_error(std::string(name) + " must contain only positive values");
+        }
+    }
+}
+
+bool range_accepts(const Score_range& range, int score_black) {
+    return range.score_min <= score_black && score_black <= range.score_max;
+}
+
+int book_value_to_black_score(const Book_elem& elem, int player) {
+    return player == BLACK ? elem.value : -elem.value;
+}
+
+bool lookup_child_after_move(Board board, int player, int policy, Candidate* candidate_out) {
+    Flip flip;
+    calc_flip(&flip, &board, policy);
+    Board child = board.move_copy(&flip);
+    int child_player = player ^ 1;
+    int lookup_player = child_player;
+    Board lookup = child.copy();
+
+    if (lookup.get_legal() == 0ULL) {
+        lookup.pass();
+        lookup_player ^= 1;
+    }
+    if (!book.contain(&lookup)) {
+        return false;
+    }
+
+    Book_elem elem = book.get(&lookup);
+    *candidate_out = Candidate{
+        policy,
+        book_value_to_black_score(elem, lookup_player),
+        child,
+        child_player,
+    };
+    return true;
+}
+
+std::vector<Candidate> enumerate_registered_candidates(Board board, int player) {
+    std::vector<Candidate> candidates;
+    uint64_t legal = board.get_legal();
+    for (uint_fast8_t cell = first_bit(&legal); legal; cell = next_bit(&legal)) {
+        Candidate candidate;
+        if (lookup_child_after_move(board, player, static_cast<int>(cell), &candidate)) {
+            candidates.emplace_back(candidate);
+        }
+    }
+    return candidates;
+}
+
+std::vector<Candidate> filter_candidates(const std::vector<Candidate>& candidates, const Score_range& range) {
+    std::vector<Candidate> filtered;
+    for (const Candidate& candidate: candidates) {
+        if (range_accepts(range, candidate.score_black)) {
+            filtered.emplace_back(candidate);
+        }
+    }
+    return filtered;
+}
+
+int count_out_of_book_moves(Board board, int player) {
+    int result = 0;
+    uint64_t legal = board.get_legal();
+    for (uint_fast8_t cell = first_bit(&legal); legal; cell = next_bit(&legal)) {
+        Candidate candidate;
+        if (!lookup_child_after_move(board, player, static_cast<int>(cell), &candidate)) {
+            ++result;
+        }
+    }
+    return result;
+}
+
+std::string candidate_summary(Board board, int player, const Score_range& range) {
+    std::vector<Candidate> candidates = enumerate_registered_candidates(board, player);
+    std::ostringstream out;
+    out << "range=" << range.score_min << ".." << range.score_max << " candidates:";
+    if (candidates.empty()) {
+        out << " <none>";
+    }
+    for (const Candidate& candidate: candidates) {
+        out << " " << idx_to_coord(candidate.policy) << "@" << candidate.score_black
+            << (range_accepts(range, candidate.score_black) ? ":keep" : ":drop");
+    }
+    int out_of_book = count_out_of_book_moves(board, player);
+    if (out_of_book > 0) {
+        out << " out_of_book=" << out_of_book;
+    }
+    return out.str();
+}
+
+class Umigame_oracle {
+private:
+    struct Cache_key {
+        Board board;
+        int player;
+        int depth;
+        int score_min;
+        int score_max;
+        int remaining_error;
+
+        bool operator==(const Cache_key& other) const {
+            return board == other.board
+                && player == other.player
+                && depth == other.depth
+                && score_min == other.score_min
+                && score_max == other.score_max
+                && remaining_error == other.remaining_error;
+        }
+    };
+
+    struct Cache_hash {
+        size_t operator()(const Cache_key& key) const {
+            size_t seed = Book_hash()(key.board);
+            hash_combine(&seed, static_cast<size_t>(key.player));
+            hash_combine(&seed, static_cast<size_t>(key.depth));
+            hash_combine(&seed, static_cast<size_t>(key.score_min + HW2));
+            hash_combine(&seed, static_cast<size_t>(key.score_max + HW2));
+            hash_combine(&seed, static_cast<size_t>(key.remaining_error));
+            return seed;
+        }
+    };
+
+    std::unordered_map<Cache_key, Umigame_result, Cache_hash> cache;
+
+public:
+    Umigame_result solve(Board board, int player, const Search_case& search_case) {
+        return solve(board, player, search_case, search_case.integration_error);
+    }
+
+private:
+    Umigame_result solve(Board board, int player, const Search_case& search_case, int remaining_error) {
+        if (!book.contain(&board) || board.n_discs() >= search_case.depth + 4) {
+            return make_result(1, 1);
+        }
+
+        Cache_key key{
+            representative_board(board),
+            player,
+            search_case.depth,
+            search_case.range.score_min,
+            search_case.range.score_max,
+            remaining_error,
+        };
+        auto found = cache.find(key);
+        if (found != cache.end()) {
+            return found->second;
+        }
+
+        if (board.get_legal() == 0ULL) {
+            player ^= 1;
+            board.pass();
+        }
+
+        std::vector<Candidate> all_candidates = enumerate_registered_candidates(board, player);
+        int best_value = -INF;
+        for (const Candidate& candidate: all_candidates) {
+            int value = player == BLACK ? candidate.score_black : -candidate.score_black;
+            best_value = std::max(best_value, value);
+        }
+        std::vector<std::pair<Candidate, int>> candidates;
+        for (const Candidate& candidate: all_candidates) {
+            int value = player == BLACK ? candidate.score_black : -candidate.score_black;
+            int local_loss = best_value - value;
+            if (local_loss <= remaining_error && range_accepts(search_case.range, candidate.score_black)) {
+                candidates.emplace_back(candidate, remaining_error - local_loss);
+            }
+        }
+        if (candidates.empty()) {
+            Umigame_result result = make_result(1, 1);
+            cache[key] = result;
+            return result;
+        }
+
+        Umigame_result result;
+        if (player == BLACK) {
+            result.b = INF;
+            result.w = 0;
+            for (const std::pair<Candidate, int>& candidate: candidates) {
+                Umigame_result child = solve(candidate.first.child, candidate.first.child_player, search_case, candidate.second);
+                result.b = std::min(result.b, child.b);
+                result.w += child.w;
+            }
+        } else {
+            result.b = 0;
+            result.w = INF;
+            for (const std::pair<Candidate, int>& candidate: candidates) {
+                Umigame_result child = solve(candidate.first.child, candidate.first.child_player, search_case, candidate.second);
+                result.w = std::min(result.w, child.w);
+                result.b += child.b;
+            }
+        }
+
+        cache[key] = result;
+        return result;
+    }
+};
+
+class Failure_reporter {
+private:
+    std::vector<Failure> failures;
+    int fail_limit;
+
+public:
+    explicit Failure_reporter(int fail_limit)
+        : fail_limit(fail_limit) {}
+
+    void add(
+        const std::string& kind,
+        const Position& position,
+        const std::string& move,
+        Search_case search_case,
+        const Umigame_result& expected,
+        const Umigame_result& actual,
+        const std::string& detail
+    ) {
+        failures.push_back(Failure{
+            kind,
+            position.transcript,
+            move,
+            position.board.to_str(position.player),
+            detail,
+            position.player,
+            search_case,
+            expected,
+            actual,
+        });
+    }
+
+    bool limit_reached() const {
+        return static_cast<int>(failures.size()) >= fail_limit;
+    }
+
+    bool empty() const {
+        return failures.empty();
+    }
+
+    size_t size() const {
+        return failures.size();
+    }
+
+    void print() const {
+        for (size_t i = 0; i < failures.size(); ++i) {
+            const Failure& failure = failures[i];
+            std::cout
+                << "\n[FAIL " << (i + 1) << "] " << failure.kind
+                << " transcript=" << (failure.transcript.empty() ? "<root>" : failure.transcript)
+                << " player=" << player_to_string(failure.player)
+                << " depth=" << failure.search_case.depth
+                << " range=" << failure.search_case.range.score_min << ".." << failure.search_case.range.score_max
+                << " integration_error=" << failure.search_case.integration_error;
+            if (!failure.move.empty()) {
+                std::cout << " move=" << failure.move;
+            }
+            std::cout
+                << "\nexpected=" << result_to_string(failure.expected)
+                << " actual=" << result_to_string(failure.actual)
+                << "\nboard=" << failure.board
+                << "\ndetail=" << failure.detail << "\n";
+        }
+    }
+};
+
+void print_usage() {
+    std::cout
+        << "Usage: umigame_regression --book <book.egbk3> [--depths 8,12,20,60]\n"
+        << "       [--ranges -64:64,0:6,3:5,-6:0]\n"
+        << "       [--integration-errors 0,2,6]\n"
+        << "       [--node-limit 100000] [--fail-limit 10] [--threads 1]\n"
+        << "       [--shard-index 0] [--shard-count 1]\n";
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        auto require_value = [&](const std::string& name) -> std::string {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("missing value for " + name);
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--book") {
+            options.book_file = require_value(arg);
+        } else if (arg == "--depths") {
+            options.depths = parse_int_list(require_value(arg));
+        } else if (arg == "--ranges") {
+            options.ranges = parse_score_ranges(require_value(arg));
+        } else if (arg == "--integration-errors") {
+            options.integration_errors = parse_int_list(require_value(arg));
+        } else if (arg == "--node-limit") {
+            options.node_limit = std::stoi(require_value(arg));
+        } else if (arg == "--fail-limit") {
+            options.fail_limit = std::stoi(require_value(arg));
+        } else if (arg == "--threads") {
+            options.threads = std::stoi(require_value(arg));
+        } else if (arg == "--shard-index") {
+            options.shard_index = std::stoi(require_value(arg));
+        } else if (arg == "--shard-count") {
+            options.shard_count = std::stoi(require_value(arg));
+        } else if (arg == "--help") {
+            print_usage();
+            std::exit(0);
+        } else {
+            throw std::runtime_error("unknown argument " + arg);
+        }
+    }
+
+    require_positive("node-limit", options.node_limit);
+    require_positive("fail-limit", options.fail_limit);
+    require_positive("threads", options.threads);
+    require_positive("shard-count", options.shard_count);
+    validate_positive_list("depths", options.depths);
+    for (int error: options.integration_errors) {
+        if (error < 0) {
+            throw std::runtime_error("integration-errors must not contain negative values");
+        }
+    }
+    if (options.shard_index < 0 || options.shard_index >= options.shard_count) {
+        throw std::runtime_error("shard-index must be in [0, shard-count)");
+    }
+    return options;
+}
+
+std::vector<Search_case> make_search_cases(const Options& options) {
+    std::vector<Search_case> search_cases;
+    for (int depth: options.depths) {
+        for (const Score_range& range: options.ranges) {
+            for (int integration_error: options.integration_errors) {
+                search_cases.push_back(Search_case{depth, range, integration_error});
+            }
+        }
+    }
+    return search_cases;
+}
+
+void initialize_engine(const Options& options) {
+    bit_init();
+    mobility_init();
+    flip_init();
+    last_flip_init();
+    endsearch_init();
+    move_ordering_init();
+    stability_init();
+    thread_pool.resize(options.threads - 1);
+
+    if (!book_init(options.book_file, false)) {
+        throw std::runtime_error("failed to load book: " + options.book_file);
+    }
+}
+
+bool should_check_shard(int64_t node_ordinal, const Options& options) {
+    return node_ordinal % options.shard_count == options.shard_index;
+}
+
+bool check_node(
+    const Position& position,
+    const std::vector<Search_case>& search_cases,
+    Umigame_oracle* oracle,
+    Failure_reporter* failures,
+    Counters* counters
+) {
+    ++counters->checked_nodes;
+
+    for (const Search_case& search_case: search_cases) {
+        Umigame_condition condition(search_case.range.score_min, search_case.range.score_max, search_case.integration_error);
+
+        Board actual_board = position.board.copy();
+        Umigame_result actual = calculate_umigame(
+            &actual_board,
+            position.player,
+            search_case.depth,
+            condition
+        );
+        Umigame_result expected = oracle->solve(position.board, position.player, search_case);
+        ++counters->checked_node_cases;
+
+        if (!same_result(actual, expected)) {
+            failures->add(
+                "node",
+                position,
+                "",
+                search_case,
+                expected,
+                actual,
+                candidate_summary(position.board, position.player, search_case.range)
+            );
+            return failures->limit_reached();
+        }
+
+        std::vector<Candidate> candidates = enumerate_registered_candidates(position.board, position.player);
+        counters->hidden_out_of_book += count_out_of_book_moves(position.board, position.player);
+        for (const Candidate& candidate: candidates) {
+            if (!range_accepts(search_case.range, candidate.score_black)) {
+                ++counters->hidden_by_score_range;
+                continue;
+            }
+            ++counters->shown_by_score_range;
+
+            Board child_actual_board = candidate.child.copy();
+            Umigame_result child_actual = calculate_umigame(
+                &child_actual_board,
+                candidate.child_player,
+                search_case.depth,
+                condition
+            );
+            Umigame_result child_expected = oracle->solve(
+                candidate.child,
+                candidate.child_player,
+                search_case
+            );
+            ++counters->checked_moves;
+
+            if (!same_result(child_actual, child_expected)) {
+                failures->add(
+                    "move",
+                    position,
+                    idx_to_coord(candidate.policy),
+                    search_case,
+                    child_expected,
+                    child_actual,
+                    "score_black=" + std::to_string(candidate.score_black)
+                );
+                return failures->limit_reached();
+            }
+        }
+    }
+
+    return false;
+}
+
+void enqueue_children(
+    const Position& position,
+    std::unordered_set<Board, Board_hash>* seen,
+    std::vector<Position>* queue
+) {
+    for (const Candidate& candidate: enumerate_registered_candidates(position.board, position.player)) {
+        Board key = representative_board(candidate.child);
+        if (seen->insert(key).second) {
+            queue->push_back(Position{
+                candidate.child,
+                candidate.child_player,
+                position.transcript + idx_to_coord(candidate.policy),
+            });
+        }
+    }
+}
+
+void print_summary(
+    const Options& options,
+    const Counters& counters,
+    const Failure_reporter& failures,
+    bool stopped_by_node_limit,
+    bool stopped_by_fail_limit
+) {
+    std::cout << "book=" << std::filesystem::absolute(options.book_file).string() << "\n";
+    std::cout << "book_size=" << book.size() << "\n";
+    std::cout << "shard=" << options.shard_index << "/" << options.shard_count << "\n";
+    std::cout << "visited_nodes=" << counters.visited_nodes << " node_limit=" << options.node_limit << "\n";
+    std::cout << "checked_nodes=" << counters.checked_nodes << "\n";
+    std::cout << "checked_node_cases=" << counters.checked_node_cases << "\n";
+    std::cout << "checked_moves=" << counters.checked_moves << "\n";
+    std::cout << "shown_by_score_range=" << counters.shown_by_score_range << "\n";
+    std::cout << "hidden_by_score_range=" << counters.hidden_by_score_range << "\n";
+    std::cout << "hidden_out_of_book=" << counters.hidden_out_of_book << "\n";
+    std::cout << "failures=" << failures.size() << " fail_limit=" << options.fail_limit << "\n";
+
+    if (stopped_by_fail_limit) {
+        std::cout << "stop_reason=fail_limit\n";
+    } else if (stopped_by_node_limit) {
+        std::cout << "stop_reason=node_limit\n";
+    } else {
+        std::cout << "stop_reason=exhausted_reachable_test_frontier\n";
+    }
+    failures.print();
+}
+
+int run(const Options& options) {
+    initialize_engine(options);
+
+    std::vector<Search_case> search_cases = make_search_cases(options);
+
+    Board root;
+    root.reset();
+    std::vector<Position> queue;
+    queue.push_back(Position{root, BLACK, ""});
+
+    std::unordered_set<Board, Board_hash> seen;
+    seen.insert(representative_board(root));
+
+    Counters counters;
+    Failure_reporter failures(options.fail_limit);
+    Umigame_oracle oracle;
+    bool stopped_by_node_limit = false;
+    bool stopped_by_fail_limit = false;
+
+    for (size_t head = 0; head < queue.size(); ++head) {
+        if (counters.visited_nodes >= options.node_limit) {
+            stopped_by_node_limit = true;
+            break;
+        }
+
+        Position position = queue[head];
+        int64_t node_ordinal = counters.visited_nodes++;
+        if (should_check_shard(node_ordinal, options)) {
+            stopped_by_fail_limit = check_node(
+                position,
+                search_cases,
+                &oracle,
+                &failures,
+                &counters
+            );
+            if (stopped_by_fail_limit) {
+                break;
+            }
+        }
+
+        enqueue_children(position, &seen, &queue);
+    }
+
+    print_summary(options, counters, failures, stopped_by_node_limit, stopped_by_fail_limit);
+    return failures.empty() ? 0 : 1;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        Options options = parse_options(argc, argv);
+        return run(options);
+    } catch (const std::exception& e) {
+        std::cerr << "[ERROR] " << e.what() << std::endl;
+        return 2;
+    }
+}


### PR DESCRIPTION
  This PR updates the Umigame extension based on developer's review.

  - Removed the Apply Setting button. Umigame settings now auto-apply with a short debounce to avoid recalculating on every slider
    frame.

  - Replaced the previous per-move loss UI with Generate random board-style settings:
      - black-perspective Score Range
      - cumulative Integration Error

  - Score Range and Integration Error are applied recursively inside Umigame search, not only as GUI display filters.
  - Integration Error = 0 intentionally allows only local best moves, preserving the original Umigame behavior for the full score
    range.

  - The Umigame cache now includes remaining integration error.
  - Top-level moves outside the book or outside the selected score range are left blank.
  - Moved regression tools under src/tools/umigame_filter_semantics/.

  Validation:

  - Source-level semantics check passed.
  - Real-book regression passed with 300000 nodes, 16 shards, fail-fast on 1 failure.
  - Generic|x64 exe build passed.

<img width="2559" height="769" alt="Screenshot 2026-06-25 174306" src="https://github.com/user-attachments/assets/8aefe2b3-7934-49e2-984c-5c534611a3ef" />
