### PR TITLE
More Detailed Timer Adjustments

### DIFF
--- a/bin/resources/languages/english.json
+++ b/bin/resources/languages/english.json
@@ -259,7 +259,7 @@
             "display_on_info_area": "On Info Area",
             "opening_name": "Opening",
             "principal_variation": "Best Line",
-            "timer": "Timer",
+            "timer": "Timer (min.)",
             "timer_time_limit": "Time Limit",
             "timer_time_limit_none": "N/A"
         },

--- a/bin/resources/languages/english.json
+++ b/bin/resources/languages/english.json
@@ -259,7 +259,9 @@
             "display_on_info_area": "On Info Area",
             "opening_name": "Opening",
             "principal_variation": "Best Line",
-            "timer": "Timer"
+            "timer": "Timer",
+            "timer_time_limit": "Time Limit",
+            "timer_time_limit_none": "N/A"
         },
         "graph": {
             "display_on_graph_area": "On Graph Area",
@@ -338,7 +340,10 @@
         "forced_finished": "Forced Line Ended",
         "playing": "Playing",
         "analyzing": "Analyzing",
-        "calculation_stopped": "AI Paused"
+        "calculation_stopped": "AI Paused",
+        "timer_start": "Start",
+        "timer_pause": "Pause",
+        "timer_reset": "Reset"
     },
     "edit_board": {
         "player": "Player",

--- a/bin/resources/languages/japanese.json
+++ b/bin/resources/languages/japanese.json
@@ -261,7 +261,9 @@
             "display_on_info_area": "情報エリアへの表示",
             "opening_name": "定石",
             "principal_variation": "最善筋",
-            "timer": "タイマー"
+            "timer": "タイマー",
+            "timer_time_limit": "時間制限",
+            "timer_time_limit_none": "なし"
         },
         "graph": {
             "display_on_graph_area": "グラフエリアへの表示",
@@ -340,7 +342,10 @@
         "forced_finished": "強制進行終了",
         "playing": "対局中",
         "analyzing": "分析中",
-        "calculation_stopped": "計算停止中"
+        "calculation_stopped": "計算停止中",
+        "timer_start": "開始",
+        "timer_pause": "一時停止",
+        "timer_reset": "リセット"
     },
     "edit_board": {
         "player": "手番",

--- a/bin/resources/languages/japanese.json
+++ b/bin/resources/languages/japanese.json
@@ -261,7 +261,7 @@
             "display_on_info_area": "情報エリアへの表示",
             "opening_name": "定石",
             "principal_variation": "最善筋",
-            "timer": "タイマー",
+            "timer": "タイマー (分)",
             "timer_time_limit": "時間制限",
             "timer_time_limit_none": "なし"
         },

--- a/bin/resources/languages/simplified_chinese.json
+++ b/bin/resources/languages/simplified_chinese.json
@@ -261,7 +261,9 @@
             "display_on_info_area": "情报显示",
             "opening_name": "定式名",
             "principal_variation": "AI推荐变化",
-            "timer": "计时器"
+            "timer": "计时器",
+            "timer_time_limit": "时间限制",
+            "timer_time_limit_none": "无"
         },
         "graph": {
             "display_on_graph_area": "图像显示",
@@ -340,7 +342,10 @@
         "forced_finished": "强制进行结束",
         "playing": "对局中",
         "analyzing": "分析中",
-        "calculation_stopped": "计算已停止"
+        "calculation_stopped": "计算已停止",
+        "timer_start": "开始",
+        "timer_pause": "暂停",
+        "timer_reset": "重置"
     },
     "edit_board": {
         "player": "玩家",

--- a/bin/resources/languages/simplified_chinese.json
+++ b/bin/resources/languages/simplified_chinese.json
@@ -261,7 +261,7 @@
             "display_on_info_area": "情报显示",
             "opening_name": "定式名",
             "principal_variation": "AI推荐变化",
-            "timer": "计时器",
+            "timer": "计时器 (分)",
             "timer_time_limit": "时间限制",
             "timer_time_limit_none": "无"
         },

--- a/bin/resources/languages/traditional_chinese_taiwan.json
+++ b/bin/resources/languages/traditional_chinese_taiwan.json
@@ -259,7 +259,7 @@
             "display_on_info_area": "顯示於資訊區",
             "opening_name": "定石名",
             "principal_variation": "最佳變化路線",
-            "timer": "計時器",
+            "timer": "計時器 (分)",
             "timer_time_limit": "時間限制",
             "timer_time_limit_none": "無"
         },

--- a/bin/resources/languages/traditional_chinese_taiwan.json
+++ b/bin/resources/languages/traditional_chinese_taiwan.json
@@ -259,7 +259,9 @@
             "display_on_info_area": "顯示於資訊區",
             "opening_name": "定石名",
             "principal_variation": "最佳變化路線",
-            "timer": "計時器"
+            "timer": "計時器",
+            "timer_time_limit": "時間限制",
+            "timer_time_limit_none": "無"
         },
         "graph": {
             "display_on_graph_area": "顯示於圖表區",
@@ -338,7 +340,10 @@
         "forced_finished": "強制進行結束",
         "playing": "對局中",
         "analyzing": "分析中",
-        "calculation_stopped": "計算已停止"
+        "calculation_stopped": "計算已停止",
+        "timer_start": "開始",
+        "timer_pause": "暫停",
+        "timer_reset": "重置"
     },
     "edit_board": {
         "player": "玩家",

--- a/src/gui/close_scene.hpp
+++ b/src/gui/close_scene.hpp
@@ -121,6 +121,7 @@ void save_settings(Menu_elements menu_elements, Settings settings, Directories d
     setting_json[U"show_opening_name"] = menu_elements.show_opening_name;
     setting_json[U"show_principal_variation"] = menu_elements.show_principal_variation;
     setting_json[U"show_timer"] = menu_elements.show_timer;
+    setting_json[U"timer_time_limit_min"] = std::clamp(menu_elements.timer_time_limit_min, TIMER_TIME_LIMIT_MIN, TIMER_TIME_LIMIT_MAX);
     setting_json[U"show_laser_pointer"] = menu_elements.show_laser_pointer;
     setting_json[U"show_ai_focus"] = menu_elements.show_ai_focus;
     setting_json[U"pv_length"] = menu_elements.pv_length;

--- a/src/gui/draw.hpp
+++ b/src/gui/draw.hpp
@@ -9,6 +9,7 @@
 */
 
 #pragma once
+#include <algorithm>
 #include <iostream>
 #include <future>
 #include <functional>
@@ -127,13 +128,13 @@ String format_elapsed_time_msec(int64_t msec) {
     return Unicode::Widen(oss.str());
 }
 
-void draw_elapsed_time_pair(const Fonts& fonts, const int font_size, const int y, const int64_t black_time_msec, const int64_t white_time_msec) {
+void draw_elapsed_time_pair(const Fonts& fonts, const Colors& colors, const int font_size, const int y, const int64_t black_time_msec, const int64_t white_time_msec, bool black_time_limit_reached = false, bool white_time_limit_reached = false) {
     constexpr int TIMER_LEFT_OFFSET = 95;
     constexpr int TIMER_RIGHT_OFFSET = 95;
     String black_time = format_elapsed_time_msec(black_time_msec);
     String white_time = format_elapsed_time_msec(white_time_msec);
-    fonts.font(black_time).draw(font_size, Arg::center(INFO_SX + INFO_WIDTH / 2 - TIMER_LEFT_OFFSET, y));
-    fonts.font(white_time).draw(font_size, Arg::center(INFO_SX + INFO_WIDTH / 2 + TIMER_RIGHT_OFFSET, y));
+    fonts.font(black_time).draw(font_size, Arg::center(INFO_SX + INFO_WIDTH / 2 - TIMER_LEFT_OFFSET, y), black_time_limit_reached ? colors.red : Palette::White);
+    fonts.font(white_time).draw(font_size, Arg::center(INFO_SX + INFO_WIDTH / 2 + TIMER_RIGHT_OFFSET, y), white_time_limit_reached ? colors.red : Palette::White);
 }
 
 String get_forced_opening_status_text(int forced_opening_status) {
@@ -159,7 +160,7 @@ String join_info_status_text(const String& lhs, const String& rhs) {
     return lhs + U" " + rhs;
 }
 
-void draw_info(Colors colors, History_elem history_elem, Fonts fonts, Menu_elements menu_elements, bool pausing_in_pass, std::string principal_variation, int forced_opening_status, int playing_mode, int64_t black_time_msec = -1, int64_t white_time_msec = -1) {
+void draw_info(Colors colors, History_elem history_elem, Fonts fonts, Menu_elements menu_elements, bool pausing_in_pass, std::string principal_variation, int forced_opening_status, int playing_mode, int64_t black_time_msec = -1, int64_t white_time_msec = -1, bool black_time_limit_reached = false, bool white_time_limit_reached = false) {
     s3d::RoundRect round_rect{ INFO_SX, INFO_SY, INFO_WIDTH, INFO_HEIGHT, INFO_RECT_RADIUS };
     round_rect.drawFrame(INFO_RECT_THICKNESS, colors.white);
     // 1st line
@@ -187,7 +188,15 @@ void draw_info(Colors colors, History_elem history_elem, Fonts fonts, Menu_eleme
     } else {
         moves_line = language.get("info", "game_end");
     }
-    fonts.font(moves_line).draw(15, Arg::topCenter(INFO_SX + INFO_WIDTH / 2, INFO_SY + dy));
+    int moves_line_font_size = 15;
+    double moves_line_max_width = INFO_WIDTH - 16;
+    if (menu_elements.show_timer && playing_mode != PLAYING_MODE_NONE) {
+        moves_line_max_width = std::max(40.0, (double)(TIMER_RESET_BUTTON_SX - (TIMER_START_BUTTON_SX + TIMER_CONTROL_BUTTON_WIDTH) - 18));
+    }
+    while (moves_line_font_size > 10 && fonts.font(moves_line).region(moves_line_font_size, Vec2{ 0, 0 }).w > moves_line_max_width) {
+        --moves_line_font_size;
+    }
+    fonts.font(moves_line).draw(moves_line_font_size, Arg::topCenter(INFO_SX + INFO_WIDTH / 2, INFO_SY + dy));
     dy += 23;
     if (black_time_msec < 0) {
         black_time_msec = history_elem.black_time_msec;
@@ -195,7 +204,15 @@ void draw_info(Colors colors, History_elem history_elem, Fonts fonts, Menu_eleme
     if (white_time_msec < 0) {
         white_time_msec = history_elem.white_time_msec;
     }
-    const bool show_timer = menu_elements.show_timer;
+    const bool show_timer = menu_elements.show_timer && !menu_elements.show_ai_focus;
+    const int timer_limit_min = std::clamp(menu_elements.timer_time_limit_min, TIMER_TIME_LIMIT_MIN, TIMER_TIME_LIMIT_MAX);
+    const int64_t timer_limit_msec = timer_limit_min <= TIMER_TIME_LIMIT_NONE ? 0 : static_cast<int64_t>(timer_limit_min) * 60 * 1000;
+    if (timer_limit_msec > 0) {
+        black_time_limit_reached = black_time_limit_reached || black_time_msec >= timer_limit_msec;
+        white_time_limit_reached = white_time_limit_reached || white_time_msec >= timer_limit_msec;
+        black_time_msec = std::max<int64_t>(0, timer_limit_msec - black_time_msec);
+        white_time_msec = std::max<int64_t>(0, timer_limit_msec - white_time_msec);
+    }
     const bool show_pv = menu_elements.show_principal_variation;
     const bool show_timer_on_line4 = show_timer;
     const bool show_level_on_line4 = !show_timer_on_line4;
@@ -272,7 +289,7 @@ void draw_info(Colors colors, History_elem history_elem, Fonts fonts, Menu_eleme
                 fonts.font(level_info).draw(12, Arg::center(INFO_SX + INFO_WIDTH / 2, up + height / 2));
             }
         } else {
-            draw_elapsed_time_pair(fonts, 11, static_cast<int>(up + height / 2), black_time_msec, white_time_msec);
+            draw_elapsed_time_pair(fonts, colors, 11, static_cast<int>(up + height / 2), black_time_msec, white_time_msec, black_time_limit_reached, white_time_limit_reached);
             if (has_line4_status_text) {
                 fonts.font(line4_status_text).draw(11, Arg::center(INFO_SX + INFO_WIDTH / 2, up + height / 2));
             }
@@ -299,7 +316,7 @@ void draw_info(Colors colors, History_elem history_elem, Fonts fonts, Menu_eleme
             }
             fonts.font(level_info).draw(12, Arg::topCenter(INFO_SX + INFO_WIDTH / 2, INFO_SY + dy));
         } else {
-            draw_elapsed_time_pair(fonts, 12, INFO_SY + dy + 8, black_time_msec, white_time_msec);
+            draw_elapsed_time_pair(fonts, colors, 12, INFO_SY + dy + 8, black_time_msec, white_time_msec, black_time_limit_reached, white_time_limit_reached);
             if (has_line4_status_text) {
                 fonts.font(line4_status_text).draw(11, Arg::center(INFO_SX + INFO_WIDTH / 2, INFO_SY + dy + 8));
             }

--- a/src/gui/draw.hpp
+++ b/src/gui/draw.hpp
@@ -128,13 +128,19 @@ String format_elapsed_time_msec(int64_t msec) {
     return Unicode::Widen(oss.str());
 }
 
-void draw_elapsed_time_pair(const Fonts& fonts, const Colors& colors, const int font_size, const int y, const int64_t black_time_msec, const int64_t white_time_msec, bool black_time_limit_reached = false, bool white_time_limit_reached = false) {
+void draw_elapsed_time_pair(const Fonts& fonts, const int font_size, const int y, const int64_t black_time_msec, const int64_t white_time_msec, bool black_time_limit_reached = false, bool white_time_limit_reached = false) {
     constexpr int TIMER_LEFT_OFFSET = 95;
     constexpr int TIMER_RIGHT_OFFSET = 95;
+    constexpr uint64_t TIMER_LIMIT_BLINK_INTERVAL_MSEC = 500;
     String black_time = format_elapsed_time_msec(black_time_msec);
     String white_time = format_elapsed_time_msec(white_time_msec);
-    fonts.font(black_time).draw(font_size, Arg::center(INFO_SX + INFO_WIDTH / 2 - TIMER_LEFT_OFFSET, y), black_time_limit_reached ? colors.red : Palette::White);
-    fonts.font(white_time).draw(font_size, Arg::center(INFO_SX + INFO_WIDTH / 2 + TIMER_RIGHT_OFFSET, y), white_time_limit_reached ? colors.red : Palette::White);
+    const bool show_limit_reached_text = (Time::GetMillisec() / TIMER_LIMIT_BLINK_INTERVAL_MSEC) % 2 == 0;
+    if (!black_time_limit_reached || show_limit_reached_text) {
+        fonts.font(black_time).draw(font_size, Arg::center(INFO_SX + INFO_WIDTH / 2 - TIMER_LEFT_OFFSET, y), Palette::White);
+    }
+    if (!white_time_limit_reached || show_limit_reached_text) {
+        fonts.font(white_time).draw(font_size, Arg::center(INFO_SX + INFO_WIDTH / 2 + TIMER_RIGHT_OFFSET, y), Palette::White);
+    }
 }
 
 String get_forced_opening_status_text(int forced_opening_status) {
@@ -289,7 +295,7 @@ void draw_info(Colors colors, History_elem history_elem, Fonts fonts, Menu_eleme
                 fonts.font(level_info).draw(12, Arg::center(INFO_SX + INFO_WIDTH / 2, up + height / 2));
             }
         } else {
-            draw_elapsed_time_pair(fonts, colors, 11, static_cast<int>(up + height / 2), black_time_msec, white_time_msec, black_time_limit_reached, white_time_limit_reached);
+            draw_elapsed_time_pair(fonts, 11, static_cast<int>(up + height / 2), black_time_msec, white_time_msec, black_time_limit_reached, white_time_limit_reached);
             if (has_line4_status_text) {
                 fonts.font(line4_status_text).draw(11, Arg::center(INFO_SX + INFO_WIDTH / 2, up + height / 2));
             }
@@ -316,7 +322,7 @@ void draw_info(Colors colors, History_elem history_elem, Fonts fonts, Menu_eleme
             }
             fonts.font(level_info).draw(12, Arg::topCenter(INFO_SX + INFO_WIDTH / 2, INFO_SY + dy));
         } else {
-            draw_elapsed_time_pair(fonts, colors, 12, INFO_SY + dy + 8, black_time_msec, white_time_msec, black_time_limit_reached, white_time_limit_reached);
+            draw_elapsed_time_pair(fonts, 12, INFO_SY + dy + 8, black_time_msec, white_time_msec, black_time_limit_reached, white_time_limit_reached);
             if (has_line4_status_text) {
                 fonts.font(line4_status_text).draw(11, Arg::center(INFO_SX + INFO_WIDTH / 2, INFO_SY + dy + 8));
             }

--- a/src/gui/function/const/gui_common.hpp
+++ b/src/gui/function/const/gui_common.hpp
@@ -206,6 +206,22 @@ constexpr int INFO_RECT_THICKNESS = 5;
 constexpr int INFO_WIDTH = WINDOW_SIZE_X - 10 - INFO_SX;
 constexpr int INFO_HEIGHT = 200 - INFO_SY - 12;
 constexpr int AI_FOCUS_INFO_COLOR_RECT_WIDTH = 90 + INFO_DISC_RADIUS + 3;
+constexpr int TIMER_CONTROL_BUTTON_WIDTH = 58;
+constexpr int TIMER_CONTROL_BUTTON_HEIGHT = 24;
+constexpr int TIMER_CONTROL_BUTTON_RADIUS = 5;
+constexpr int TIMER_CONTROL_BUTTON_MARGIN_X = 12;
+constexpr int TIMER_CONTROL_BUTTON_TOP_Y = INFO_SY + 11;
+constexpr int TIMER_START_BUTTON_SX = INFO_SX + TIMER_CONTROL_BUTTON_MARGIN_X;
+constexpr int TIMER_START_BUTTON_SY = TIMER_CONTROL_BUTTON_TOP_Y;
+constexpr int TIMER_RESET_BUTTON_SX = INFO_SX + INFO_WIDTH - TIMER_CONTROL_BUTTON_MARGIN_X - TIMER_CONTROL_BUTTON_WIDTH;
+constexpr int TIMER_RESET_BUTTON_SY = TIMER_CONTROL_BUTTON_TOP_Y;
+constexpr int TIMER_PAUSE_BUTTON_SX = INFO_SX + (INFO_WIDTH - TIMER_CONTROL_BUTTON_WIDTH) / 2;
+constexpr int TIMER_PAUSE_BUTTON_SY = INFO_SY + 83;
+constexpr int TIMER_CONTROL_BUTTON_FONT_SIZE = 12;
+constexpr int TIMER_TIME_LIMIT_NONE = 0;
+constexpr int TIMER_TIME_LIMIT_MIN = TIMER_TIME_LIMIT_NONE;
+constexpr int TIMER_TIME_LIMIT_MAX = 60;
+constexpr int TIMER_TIME_LIMIT_DEFAULT = TIMER_TIME_LIMIT_NONE;
 
 // graph mode constants
 constexpr int GRAPH_MODE_NORMAL = 0;
@@ -582,6 +598,7 @@ struct Settings {
     bool show_opening_name;
     bool show_principal_variation;
     bool show_timer;
+    int timer_time_limit_min;
     bool show_ai_focus;
     int pv_length;
     std::string screenshot_saving_dir;
@@ -735,6 +752,7 @@ struct Menu_elements {
     bool show_opening_name;
     bool show_principal_variation;
     bool show_timer;
+    int timer_time_limit_min;
     bool show_ai_focus;
     int pv_length;
     bool show_value_when_ai_calculating;
@@ -896,6 +914,7 @@ struct Menu_elements {
         show_opening_name = settings->show_opening_name;
         show_principal_variation = settings->show_principal_variation;
         show_timer = settings->show_timer;
+        timer_time_limit_min = settings->timer_time_limit_min;
         show_ai_focus = settings->show_ai_focus;
         pv_length = settings->pv_length;
         show_value_when_ai_calculating = settings->show_value_when_ai_calculating;

--- a/src/gui/function/display_profile.hpp
+++ b/src/gui/function/display_profile.hpp
@@ -45,6 +45,7 @@ struct Display_profile_values {
     bool show_opening_name{ true };
     bool show_principal_variation{ true };
     bool show_timer{ false };
+    int timer_time_limit_min{ TIMER_TIME_LIMIT_DEFAULT };
     bool show_ai_focus{ false };
     int pv_length{ 7 };
     bool show_value_when_ai_calculating{ false };
@@ -81,6 +82,7 @@ inline void normalize_display_profile_values(Display_profile_values* values) {
     }
     values->umigame_value_integration_error = std::clamp(values->umigame_value_integration_error, UMIGAME_VALUE_INTEGRATION_ERROR_MIN, UMIGAME_VALUE_INTEGRATION_ERROR_MAX);
     values->pv_length = std::clamp(values->pv_length, PV_LENGTH_SETTING_MIN, PV_LENGTH_SETTING_MAX);
+    values->timer_time_limit_min = std::clamp(values->timer_time_limit_min, TIMER_TIME_LIMIT_MIN, TIMER_TIME_LIMIT_MAX);
 
     if (values->play_ordering_board_format == values->play_ordering_transcript_format) {
         values->play_ordering_board_format = true;
@@ -128,6 +130,7 @@ inline Display_profile_values to_display_profile_values(const Settings& settings
     values.show_opening_name = settings.show_opening_name;
     values.show_principal_variation = settings.show_principal_variation;
     values.show_timer = settings.show_timer;
+    values.timer_time_limit_min = settings.timer_time_limit_min;
     values.show_ai_focus = settings.show_ai_focus;
     values.pv_length = settings.pv_length;
     values.show_value_when_ai_calculating = settings.show_value_when_ai_calculating;
@@ -171,6 +174,7 @@ inline Display_profile_values to_display_profile_values(const Menu_elements& men
     values.show_opening_name = menu_elements.show_opening_name;
     values.show_principal_variation = menu_elements.show_principal_variation;
     values.show_timer = menu_elements.show_timer;
+    values.timer_time_limit_min = menu_elements.timer_time_limit_min;
     values.show_ai_focus = menu_elements.show_ai_focus;
     values.pv_length = menu_elements.pv_length;
     values.show_value_when_ai_calculating = menu_elements.show_value_when_ai_calculating;
@@ -215,6 +219,7 @@ inline void apply_display_profile_values(const Display_profile_values& values, S
     settings->show_opening_name = normalized_values.show_opening_name;
     settings->show_principal_variation = normalized_values.show_principal_variation;
     settings->show_timer = normalized_values.show_timer;
+    settings->timer_time_limit_min = normalized_values.timer_time_limit_min;
     settings->show_ai_focus = normalized_values.show_ai_focus;
     settings->pv_length = normalized_values.pv_length;
     settings->show_value_when_ai_calculating = normalized_values.show_value_when_ai_calculating;
@@ -257,6 +262,7 @@ inline void apply_display_profile_values(const Display_profile_values& values, M
     menu_elements->show_opening_name = normalized_values.show_opening_name;
     menu_elements->show_principal_variation = normalized_values.show_principal_variation;
     menu_elements->show_timer = normalized_values.show_timer;
+    menu_elements->timer_time_limit_min = normalized_values.timer_time_limit_min;
     menu_elements->show_ai_focus = normalized_values.show_ai_focus;
     menu_elements->pv_length = normalized_values.pv_length;
     menu_elements->show_value_when_ai_calculating = normalized_values.show_value_when_ai_calculating;
@@ -325,6 +331,7 @@ inline void export_display_profile_json(JSON& json, const Display_profile_values
     json[U"show_opening_name"] = normalized_values.show_opening_name;
     json[U"show_principal_variation"] = normalized_values.show_principal_variation;
     json[U"show_timer"] = normalized_values.show_timer;
+    json[U"timer_time_limit_min"] = normalized_values.timer_time_limit_min;
     json[U"show_ai_focus"] = normalized_values.show_ai_focus;
     json[U"pv_length"] = normalized_values.pv_length;
     json[U"show_value_when_ai_calculating"] = normalized_values.show_value_when_ai_calculating;
@@ -374,6 +381,7 @@ inline bool load_display_profile_values(const FilePath& path, Display_profile_va
     import_display_profile_bool(json, U"show_opening_name", &values->show_opening_name);
     import_display_profile_bool(json, U"show_principal_variation", &values->show_principal_variation);
     import_display_profile_bool(json, U"show_timer", &values->show_timer);
+    import_display_profile_int(json, U"timer_time_limit_min", &values->timer_time_limit_min);
     import_display_profile_bool(json, U"show_ai_focus", &values->show_ai_focus);
     import_display_profile_int(json, U"pv_length", &values->pv_length);
     import_display_profile_bool(json, U"show_value_when_ai_calculating", &values->show_value_when_ai_calculating);
@@ -428,6 +436,7 @@ inline bool equals_display_profile_values(const Display_profile_values& lhs, con
     if (lhs.show_opening_name != rhs.show_opening_name) return false;
     if (lhs.show_principal_variation != rhs.show_principal_variation) return false;
     if (lhs.show_timer != rhs.show_timer) return false;
+    if (lhs.timer_time_limit_min != rhs.timer_time_limit_min) return false;
     if (lhs.show_ai_focus != rhs.show_ai_focus) return false;
     if (lhs.pv_length != rhs.pv_length) return false;
     if (lhs.show_value_when_ai_calculating != rhs.show_value_when_ai_calculating) return false;

--- a/src/gui/function/menu.hpp
+++ b/src/gui/function/menu.hpp
@@ -207,6 +207,19 @@ private:
         }
     }
 
+    int bar_value_display_width() {
+        int width = 0;
+        if (mode == MENU_MODE_BAR_CHECK) {
+            width = std::max(width, static_cast<int>(font(unchecked_str).region(font_size, Vec2{ 0, 0 }).w));
+        }
+        if (mode == MENU_MODE_BAR || mode == MENU_MODE_BAR_CHECK) {
+            width = std::max(width, static_cast<int>(font(format_bar_value(min_elem)).region(font_size, Vec2{ 0, 0 }).w));
+            width = std::max(width, static_cast<int>(font(format_bar_value(max_elem)).region(font_size, Vec2{ 0, 0 }).w));
+            width = std::max(width, static_cast<int>(font(format_bar_value(*bar_elem)).region(font_size, Vec2{ 0, 0 }).w));
+        }
+        return width;
+    }
+
 public:
     void init_button(String s, bool *c) {
         clear();
@@ -523,7 +536,7 @@ public:
         }
         // check clicked
         if (mode == MENU_MODE_BAR_CHECK) {
-            Rect bar_check_rect = Rect(rect.x, rect.y, bar_sx - bar_value_offset - rect.x, rect.h);
+            Rect bar_check_rect = Rect(rect.x, rect.y, bar_sx - std::max(bar_value_offset, bar_value_display_width()) - 8 - rect.x, rect.h);
             click_supporter.update(bar_check_rect);
             is_clicked = click_supporter.clicked();
         } else {
@@ -568,11 +581,13 @@ public:
             font(str).draw(font_size, rect.x + rect.h - menu_offset_y, rect.y + menu_offset_y, menu_font_color);
         }
         if (mode == MENU_MODE_BAR || mode == MENU_MODE_BAR_CHECK) {
+            String bar_value_text;
             if (mode == MENU_MODE_BAR_CHECK && !(*is_checked)) {
-                font(unchecked_str).draw(font_size, Arg::topRight(bar_sx - menu_child_offset - 4, rect.y + menu_offset_y), menu_font_color);
+                bar_value_text = unchecked_str;
             } else {
-                font(format_bar_value(*bar_elem)).draw(font_size, Arg::topRight(bar_sx - menu_child_offset - 4, rect.y + menu_offset_y), menu_font_color);
+                bar_value_text = format_bar_value(*bar_elem);
             }
+            font(bar_value_text).draw(font_size, Arg::topRight(bar_sx - menu_child_offset - 4, rect.y + menu_offset_y), menu_font_color);
             if (mode == MENU_MODE_BAR_CHECK && !(*is_checked)) {
                 bar_rect.draw(ColorF(bar_color, 0.5));
             } else {
@@ -683,7 +698,7 @@ public:
         }
         w += h;
         if (mode == MENU_MODE_BAR || mode == MENU_MODE_BAR_CHECK) {
-            w += MENU_BAR_SIZE + bar_value_offset + bar_additional_offset;
+            w += MENU_BAR_SIZE + std::max(bar_value_offset, bar_value_display_width()) + 8 + bar_additional_offset;
         } else if (mode == MENU_MODE_2BARS) {
             w += MENU_BAR_SIZE + bar_value_offset * 3 + bar_additional_offset;
         }

--- a/src/gui/function/menu.hpp
+++ b/src/gui/function/menu.hpp
@@ -142,8 +142,12 @@ private:
     bool use_image;
     Texture image;
     int (*bar_display_mapper)(int);
+    String (*bar_display_formatter)(int);
 
     String format_bar_value(int value) const {
+        if (bar_display_formatter != nullptr) {
+            return bar_display_formatter(value);
+        }
         if (bar_display_mapper == nullptr) {
             return Format(value);
         }
@@ -256,6 +260,7 @@ public:
         use_image = false;
         arrow_left = al;
         bar_display_mapper = nullptr;
+        bar_display_formatter = nullptr;
     }
 
     void init_bar(String s, int *c, int d, int mn, int mx) {
@@ -275,10 +280,15 @@ public:
         is_clicked = false;
         use_image = false;
         bar_display_mapper = nullptr;
+        bar_display_formatter = nullptr;
     }
 
     void set_bar_display_mapper(int (*mapper)(int)) {
         bar_display_mapper = mapper;
+    }
+
+    void set_bar_display_formatter(String (*formatter)(int)) {
+        bar_display_formatter = formatter;
     }
 
     void init_check(String s, bool *c, bool d) {
@@ -695,6 +705,7 @@ public:
         str = U"";
         bar_active_circle = 0;
         bar_display_mapper = nullptr;
+        bar_display_formatter = nullptr;
     }
 
     int menu_mode() const {

--- a/src/gui/function/menu_definition.hpp
+++ b/src/gui/function/menu_definition.hpp
@@ -24,6 +24,13 @@ String get_shortcut_key_info(String key) {
     return U" (" + res + U")";
 }
 
+String format_timer_time_limit_min(int value) {
+    if (value <= TIMER_TIME_LIMIT_NONE) {
+        return language.get("display", "info", "timer_time_limit_none");
+    }
+    return Format(value);
+}
+
 Menu create_menu(Menu_elements* menu_elements, Resources *resources, Font font, std::string lang_name) {
     Menu menu;
     menu_title title;
@@ -149,7 +156,8 @@ Menu create_menu(Menu_elements* menu_elements, Resources *resources, Font font, 
         menu_e.init_button(language.get("display", "info", "display_on_info_area"), &menu_elements->dummy);
             side_menu.init_check(language.get("display", "info", "opening_name") + get_shortcut_key_info(U"show_opening_name"), &menu_elements->show_opening_name, menu_elements->show_opening_name);
             menu_e.push(side_menu);
-            side_menu.init_check(language.get("display", "info", "timer") + get_shortcut_key_info(U"show_timer"), &menu_elements->show_timer, menu_elements->show_timer);
+            side_menu.init_bar_check(language.get("display", "info", "timer") + get_shortcut_key_info(U"show_timer"), &menu_elements->timer_time_limit_min, menu_elements->timer_time_limit_min, TIMER_TIME_LIMIT_MIN, TIMER_TIME_LIMIT_MAX, &menu_elements->show_timer, menu_elements->show_timer, U"×");
+            side_menu.set_bar_display_formatter(format_timer_time_limit_min);
             menu_e.push(side_menu);
             side_menu.init_bar_check(language.get("display", "info", "principal_variation") + get_shortcut_key_info(U"show_principal_variation"), &menu_elements->pv_length, menu_elements->pv_length, PV_LENGTH_SETTING_MIN, PV_LENGTH_SETTING_MAX, &menu_elements->show_principal_variation, menu_elements->show_principal_variation, U"-");
             menu_e.push(side_menu);

--- a/src/gui/main_scene.hpp
+++ b/src/gui/main_scene.hpp
@@ -46,6 +46,9 @@ private:
     AI_status ai_status;
     Button start_game_button;
     Button pass_button;
+    Button timer_start_button;
+    Button timer_pause_button;
+    Button timer_reset_button;
     std::vector<Button> shortcut_buttons_grid;
     bool need_start_game_button;
     Umigame_status umigame_status;
@@ -66,6 +69,8 @@ private:
     Board turn_timer_anchor_board;
     int turn_timer_anchor_player;
     int turn_timer_anchor_branch;
+    bool turn_timer_paused;
+    bool turn_timer_started;
     bool forced_opening_finished_latched;
     bool ai_calculation_interrupted;
     bool hint_calculation_interrupted;
@@ -108,6 +113,7 @@ public:
         }
         start_game_button.init(START_GAME_BUTTON_SX, START_GAME_BUTTON_SY, START_GAME_BUTTON_WIDTH, START_GAME_BUTTON_HEIGHT, START_GAME_BUTTON_RADIUS, language.get("play", "start_game"), 15, getData().fonts.font, getData().colors.white, getData().colors.black);
         pass_button.init(PASS_BUTTON_SX, PASS_BUTTON_SY, PASS_BUTTON_WIDTH, PASS_BUTTON_HEIGHT, PASS_BUTTON_RADIUS, language.get("play", "pass"), 15, getData().fonts.font, getData().colors.white, getData().colors.black);
+        init_timer_control_buttons();
         shortcut_buttons_grid.clear();
         for (int i = 0; i < SHORTCUT_BUTTON_GRID_COUNT; ++i) {
             Button button;
@@ -127,6 +133,8 @@ public:
         umigame_value_setting_changed_msec = 0;
         shortcut_key = SHORTCUT_KEY_UNDEFINED;
         shortcut_key_pressed = SHORTCUT_KEY_UNDEFINED;
+        turn_timer_paused = true;
+        turn_timer_started = false;
         forced_opening_finished_latched = false;
         ai_calculation_interrupted = false;
         hint_calculation_interrupted = false;
@@ -233,6 +241,8 @@ public:
             start_game_button.draw();
             if (!getData().menu.active() && (start_game_button.clicked() || shortcut_key == U"start_game")) {
                 need_start_game_button = false;
+                turn_timer_paused = true;
+                turn_timer_started = false;
                 reset_turn_timer_anchor();
                 stop_calculating();
                 resume_calculating();
@@ -257,6 +267,7 @@ public:
                 }
             }
         }
+        update_auto_ai_turn_timer();
         if (!ignore_move) {
             if (ai_should_move) {
                 ai_move();
@@ -422,8 +433,12 @@ public:
         int64_t display_black_time_msec;
         int64_t display_white_time_msec;
         get_display_timer_values(&display_black_time_msec, &display_white_time_msec);
+        const uint64_t timer_limit_msec = get_timer_time_limit_msec();
+        const bool black_time_limit_reached = timer_limit_msec > 0ULL && display_black_time_msec >= 0 && static_cast<uint64_t>(display_black_time_msec) >= timer_limit_msec;
+        const bool white_time_limit_reached = timer_limit_msec > 0ULL && display_white_time_msec >= 0 && static_cast<uint64_t>(display_white_time_msec) >= timer_limit_msec;
         int forced_opening_status = get_forced_opening_status_for_display();
-        draw_info(getData().colors, getData().history_elem, getData().fonts, getData().menu_elements, pausing_in_pass, principal_variation, forced_opening_status, playing_mode, display_black_time_msec, display_white_time_msec);
+        draw_info(getData().colors, getData().history_elem, getData().fonts, getData().menu_elements, pausing_in_pass, principal_variation, forced_opening_status, playing_mode, display_black_time_msec, display_white_time_msec, black_time_limit_reached, white_time_limit_reached);
+        update_timer_control_buttons();
 
         // draw local strategy policy
         if (ai_status.local_strategy_policy_done_level > 0 && getData().menu_elements.show_ai_focus && !local_strategy_ignore && !getData().menu.active()) {
@@ -481,6 +496,12 @@ private:
         turn_timer_anchor_branch = getData().graph_resources.branch;
     }
 
+    void reset_turn_timer_state() {
+        turn_timer_paused = true;
+        turn_timer_started = false;
+        reset_turn_timer_anchor();
+    }
+
     void sync_turn_timer_anchor_if_needed() {
         if (
             turn_timer_anchor_board != getData().history_elem.board ||
@@ -491,19 +512,23 @@ private:
         }
     }
 
-    void get_display_timer_values(int64_t* black_time_msec, int64_t* white_time_msec) {
-        *black_time_msec = getData().history_elem.black_time_msec;
-        *white_time_msec = getData().history_elem.white_time_msec;
+    bool is_turn_timer_countable_position() {
         bool latest_normal_position =
             getData().graph_resources.branch == GRAPH_MODE_NORMAL &&
             getData().graph_resources.nodes[GRAPH_MODE_NORMAL].size() &&
             getData().history_elem.board == getData().graph_resources.nodes[GRAPH_MODE_NORMAL].back().board;
-        bool timer_running =
+        return
             latest_normal_position &&
             !need_start_game_button &&
             !pausing_in_pass &&
             !changing_scene &&
             !getData().history_elem.board.is_end();
+    }
+
+    void get_display_timer_values(int64_t* black_time_msec, int64_t* white_time_msec) {
+        *black_time_msec = getData().history_elem.black_time_msec;
+        *white_time_msec = getData().history_elem.white_time_msec;
+        bool timer_running = is_turn_timer_countable_position() && !turn_timer_paused;
         if (timer_running) {
             sync_turn_timer_anchor_if_needed();
             int64_t elapsed = static_cast<int64_t>(Time::GetMillisec()) - static_cast<int64_t>(turn_timer_start_msec);
@@ -544,8 +569,31 @@ private:
         return FORCED_OPENING_STATUS_OUT;
     }
 
+    int get_current_history_node_idx() {
+        // node_find() matches by disc count, so verify the exact board/player before writing timer values.
+        int node_idx = getData().graph_resources.node_find(getData().graph_resources.branch, getData().history_elem.board.n_discs());
+        if (node_idx == -1) {
+            return -1;
+        }
+        const History_elem& node = getData().graph_resources.nodes[getData().graph_resources.branch][node_idx];
+        if (node.board != getData().history_elem.board || node.player != getData().history_elem.player) {
+            return -1;
+        }
+        return node_idx;
+    }
+
+    void sync_current_timer_to_graph_node(int node_idx) {
+        if (node_idx != -1) {
+            getData().graph_resources.nodes[getData().graph_resources.branch][node_idx].black_time_msec = getData().history_elem.black_time_msec;
+            getData().graph_resources.nodes[getData().graph_resources.branch][node_idx].white_time_msec = getData().history_elem.white_time_msec;
+        }
+    }
+
     void add_elapsed_time_to_current_player(int node_idx) {
         sync_turn_timer_anchor_if_needed();
+        if (turn_timer_paused || !is_turn_timer_countable_position()) {
+            return;
+        }
         int64_t elapsed = static_cast<int64_t>(Time::GetMillisec()) - static_cast<int64_t>(turn_timer_start_msec);
         if (elapsed < 0) {
             elapsed = 0;
@@ -555,9 +603,110 @@ private:
         } else {
             getData().history_elem.white_time_msec += elapsed;
         }
-        if (node_idx != -1) {
-            getData().graph_resources.nodes[getData().graph_resources.branch][node_idx].black_time_msec = getData().history_elem.black_time_msec;
-            getData().graph_resources.nodes[getData().graph_resources.branch][node_idx].white_time_msec = getData().history_elem.white_time_msec;
+        sync_current_timer_to_graph_node(node_idx);
+    }
+
+    void settle_turn_timer_if_countable() {
+        if (turn_timer_paused || !is_turn_timer_countable_position()) {
+            reset_turn_timer_anchor();
+            return;
+        }
+        add_elapsed_time_to_current_player(get_current_history_node_idx());
+        reset_turn_timer_anchor();
+    }
+
+    void pause_turn_timer() {
+        if (turn_timer_paused) {
+            return;
+        }
+        add_elapsed_time_to_current_player(get_current_history_node_idx());
+        turn_timer_paused = true;
+        reset_turn_timer_anchor();
+    }
+
+    void start_turn_timer() {
+        turn_timer_paused = false;
+        turn_timer_started = true;
+        reset_turn_timer_anchor();
+    }
+
+    void reset_turn_timer_values() {
+        getData().history_elem.black_time_msec = 0;
+        getData().history_elem.white_time_msec = 0;
+        for (int branch = 0; branch < 2; ++branch) {
+            for (History_elem& node : getData().graph_resources.nodes[branch]) {
+                node.black_time_msec = 0;
+                node.white_time_msec = 0;
+            }
+        }
+        reset_turn_timer_anchor();
+    }
+
+    bool is_current_player_ai_controlled() {
+        if (putting_1_move_by_ai) {
+            return true;
+        }
+        return
+            (getData().history_elem.player == BLACK && getData().menu_elements.ai_put_black) ||
+            (getData().history_elem.player == WHITE && getData().menu_elements.ai_put_white);
+    }
+
+    void update_auto_ai_turn_timer() {
+        const bool should_auto_run = getData().menu_elements.show_timer && is_current_player_ai_controlled() && is_turn_timer_countable_position();
+        if (should_auto_run && turn_timer_paused && !turn_timer_started) {
+            start_turn_timer();
+        }
+    }
+
+    uint64_t get_timer_time_limit_msec() const {
+        const int limit_min = std::clamp(getData().menu_elements.timer_time_limit_min, TIMER_TIME_LIMIT_MIN, TIMER_TIME_LIMIT_MAX);
+        return limit_min <= TIMER_TIME_LIMIT_NONE ? 0ULL : static_cast<uint64_t>(limit_min) * 60ULL * 1000ULL;
+    }
+
+    void init_timer_control_buttons() {
+        timer_start_button.init(TIMER_START_BUTTON_SX, TIMER_START_BUTTON_SY, TIMER_CONTROL_BUTTON_WIDTH, TIMER_CONTROL_BUTTON_HEIGHT, TIMER_CONTROL_BUTTON_RADIUS, language.get("info", "timer_start"), TIMER_CONTROL_BUTTON_FONT_SIZE, getData().fonts.font, getData().colors.white, getData().colors.black);
+        timer_pause_button.init(TIMER_PAUSE_BUTTON_SX, TIMER_PAUSE_BUTTON_SY, TIMER_CONTROL_BUTTON_WIDTH, TIMER_CONTROL_BUTTON_HEIGHT, TIMER_CONTROL_BUTTON_RADIUS, language.get("info", "timer_pause"), TIMER_CONTROL_BUTTON_FONT_SIZE, getData().fonts.font, getData().colors.white, getData().colors.black);
+        timer_reset_button.init(TIMER_RESET_BUTTON_SX, TIMER_RESET_BUTTON_SY, TIMER_CONTROL_BUTTON_WIDTH, TIMER_CONTROL_BUTTON_HEIGHT, TIMER_CONTROL_BUTTON_RADIUS, language.get("info", "timer_reset"), TIMER_CONTROL_BUTTON_FONT_SIZE, getData().fonts.font, getData().colors.white, getData().colors.black);
+    }
+
+    void update_timer_control_buttons() {
+        if (!getData().menu_elements.show_timer || getData().menu_elements.show_ai_focus) {
+            return;
+        }
+        timer_start_button.move(TIMER_START_BUTTON_SX, TIMER_START_BUTTON_SY);
+        timer_pause_button.move(TIMER_PAUSE_BUTTON_SX, TIMER_PAUSE_BUTTON_SY);
+        timer_reset_button.move(TIMER_RESET_BUTTON_SX, TIMER_RESET_BUTTON_SY);
+
+        const bool menu_active = getData().menu.active();
+        const bool countable_position = is_turn_timer_countable_position();
+        if (menu_active || !turn_timer_paused || !countable_position) {
+            timer_start_button.disable();
+        } else {
+            timer_start_button.enable();
+        }
+        if (menu_active || turn_timer_paused || !countable_position) {
+            timer_pause_button.disable();
+        } else {
+            timer_pause_button.enable();
+        }
+        if (menu_active) {
+            timer_reset_button.disable();
+        } else {
+            timer_reset_button.enable();
+        }
+
+        timer_start_button.draw();
+        timer_pause_button.draw();
+        timer_reset_button.draw();
+
+        if (!menu_active && turn_timer_paused && timer_start_button.clicked()) {
+            start_turn_timer();
+        }
+        if (!menu_active && !turn_timer_paused && countable_position && timer_pause_button.clicked()) {
+            pause_turn_timer();
+        }
+        if (!menu_active && timer_reset_button.clicked()) {
+            reset_turn_timer_values();
         }
     }
 
@@ -833,6 +982,8 @@ private:
             getData().graph_resources.nodes[getData().graph_resources.branch].emplace_back(getData().history_elem);
             getData().game_information.init();
             forced_opening_finished_latched = false;
+            turn_timer_paused = true;
+            turn_timer_started = false;
             reset_turn_timer_anchor();
             getData().menu_elements.ai_put_black = false;
             getData().menu_elements.ai_put_white = false;
@@ -847,6 +998,8 @@ private:
             getData().graph_resources.nodes[getData().graph_resources.branch].emplace_back(getData().history_elem);
             getData().game_information.init();
             forced_opening_finished_latched = false;
+            turn_timer_paused = true;
+            turn_timer_started = false;
             reset_turn_timer_anchor();
             getData().menu_elements.ai_put_black = false;
             getData().menu_elements.ai_put_white = true;
@@ -861,6 +1014,8 @@ private:
             getData().graph_resources.nodes[getData().graph_resources.branch].emplace_back(getData().history_elem);
             getData().game_information.init();
             forced_opening_finished_latched = false;
+            turn_timer_paused = true;
+            turn_timer_started = false;
             reset_turn_timer_anchor();
             getData().menu_elements.ai_put_black = true;
             getData().menu_elements.ai_put_white = false;
@@ -875,6 +1030,8 @@ private:
             getData().graph_resources.nodes[getData().graph_resources.branch].emplace_back(getData().history_elem);
             getData().game_information.init();
             forced_opening_finished_latched = false;
+            turn_timer_paused = true;
+            turn_timer_started = false;
             reset_turn_timer_anchor();
             getData().menu_elements.ai_put_black = true;
             getData().menu_elements.ai_put_white = true;
@@ -1222,6 +1379,7 @@ private:
                 getData().graph_resources.nodes[getData().graph_resources.branch].emplace_back(getData().history_elem);
                 getData().game_information.init();
                 pausing_in_pass = false;
+                reset_turn_timer_state();
                 resume_calculating();
                 ai_status.random_board_generator_calculating = true;
                 ai_status.random_board_generator_future = std::async(std::launch::async, random_board_generator, getData().menu_elements.generate_random_board_score_range_min, getData().menu_elements.generate_random_board_score_range_max, getData().menu_elements.generate_random_board_moves, light_level, mid_level, adjustment_level, &ai_status.random_board_generator_calculating);
@@ -1698,6 +1856,7 @@ private:
                     getData().menu = create_menu(&getData().menu_elements, &getData().resources, getData().fonts.font, getData().resources.language_names[i]);
                     start_game_button.init(START_GAME_BUTTON_SX, START_GAME_BUTTON_SY, START_GAME_BUTTON_WIDTH, START_GAME_BUTTON_HEIGHT, START_GAME_BUTTON_RADIUS, language.get("play", "start_game"), 15, getData().fonts.font, getData().colors.white, getData().colors.black);
                     pass_button.init(PASS_BUTTON_SX, PASS_BUTTON_SY, PASS_BUTTON_WIDTH, PASS_BUTTON_HEIGHT, PASS_BUTTON_RADIUS, language.get("play", "pass"), 15, getData().fonts.font, getData().colors.white, getData().colors.black);
+                    init_timer_control_buttons();
                     re_calculate_openings();
                 }
             }
@@ -1773,6 +1932,9 @@ private:
             stop_calculating();
             resume_calculating();
         }
+        if (history_changed) {
+            settle_turn_timer_if_countable();
+        }
         getData().history_elem = next_history_elem;
         if (history_changed) {
             reset_turn_timer_anchor();
@@ -1817,6 +1979,7 @@ private:
         }
         update_xot_start_n_discs(&getData().graph_resources);
         reset_turn_timer_anchor();
+        update_auto_ai_turn_timer();
         resume_calculating();
     }
 
@@ -1914,6 +2077,7 @@ private:
                     }
                     ai_status.ai_thinking = false;
                     putting_1_move_by_ai = false;
+                    update_auto_ai_turn_timer();
                 }
             }
         }
@@ -3195,6 +3359,7 @@ private:
         getData().graph_resources.nodes[getData().graph_resources.branch].emplace_back(getData().history_elem);
         getData().game_information.init();
         pausing_in_pass = false;
+        reset_turn_timer_state();
         resume_calculating();
         for (int policy : moves) {
             move_processing(HW2_M1 - policy);
@@ -3215,6 +3380,7 @@ private:
                 getData().graph_resources.nodes[getData().graph_resources.branch].emplace_back(getData().history_elem);
                 getData().game_information.init();
                 pausing_in_pass = false;
+                reset_turn_timer_state();
                 resume_calculating();
                 for (int policy : moves) {
                     move_processing(HW2_M1 - policy);

--- a/src/gui/silent_load_scene.hpp
+++ b/src/gui/silent_load_scene.hpp
@@ -94,6 +94,7 @@ void init_default_settings(const Directories* directories, const Resources* reso
     settings->show_opening_name = true;
     settings->show_principal_variation = true;
     settings->show_timer = false;
+    settings->timer_time_limit_min = TIMER_TIME_LIMIT_DEFAULT;
     settings->show_laser_pointer = false;
     settings->show_ai_focus = false;
     settings->pv_length = 7;
@@ -479,6 +480,7 @@ void init_settings(const Directories* directories, const Resources* resources, S
         if (init_settings_import_bool(setting_json, U"show_timer", &settings->show_timer) != ERR_OK) {
             std::cerr << "err40-1" << std::endl;
         }
+        init_settings_import_int(setting_json, U"timer_time_limit_min", &settings->timer_time_limit_min);
         if (init_settings_import_bool(setting_json, U"show_laser_pointer", &settings->show_laser_pointer) != ERR_OK) {
             std::cerr << "err41" << std::endl;
         }
@@ -574,6 +576,7 @@ void init_settings(const Directories* directories, const Resources* resources, S
     settings->othello_quest_mode = std::clamp(settings->othello_quest_mode, 0, 2);
     settings->auto_save_ai_profile_mode = std::clamp(settings->auto_save_ai_profile_mode, PROFILE_AUTO_SAVE_MODE_OVERWRITE, PROFILE_AUTO_SAVE_MODE_NEW);
     settings->auto_save_display_profile_mode = std::clamp(settings->auto_save_display_profile_mode, PROFILE_AUTO_SAVE_MODE_OVERWRITE, PROFILE_AUTO_SAVE_MODE_NEW);
+    settings->timer_time_limit_min = std::clamp(settings->timer_time_limit_min, TIMER_TIME_LIMIT_MIN, TIMER_TIME_LIMIT_MAX);
     if (setting_json[U"umigame_value_score_slider_version"].getType() != JSONValueType::Number) {
         settings->umigame_value_score_min = migrate_legacy_umigame_score_slider_value(settings->umigame_value_score_min);
         settings->umigame_value_score_max = migrate_legacy_umigame_score_slider_value(settings->umigame_value_score_max);

--- a/src/tools/release_script/format_files/0_common_files/languages/english.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/english.json
@@ -259,7 +259,7 @@
             "display_on_info_area": "On Info Area",
             "opening_name": "Opening",
             "principal_variation": "Best Line",
-            "timer": "Timer",
+            "timer": "Timer (min.)",
             "timer_time_limit": "Time Limit",
             "timer_time_limit_none": "N/A"
         },

--- a/src/tools/release_script/format_files/0_common_files/languages/english.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/english.json
@@ -259,7 +259,9 @@
             "display_on_info_area": "On Info Area",
             "opening_name": "Opening",
             "principal_variation": "Best Line",
-            "timer": "Timer"
+            "timer": "Timer",
+            "timer_time_limit": "Time Limit",
+            "timer_time_limit_none": "N/A"
         },
         "graph": {
             "display_on_graph_area": "On Graph Area",
@@ -338,7 +340,10 @@
         "forced_finished": "Forced Line Ended",
         "playing": "Playing",
         "analyzing": "Analyzing",
-        "calculation_stopped": "AI Paused"
+        "calculation_stopped": "AI Paused",
+        "timer_start": "Start",
+        "timer_pause": "Pause",
+        "timer_reset": "Reset"
     },
     "edit_board": {
         "player": "Player",

--- a/src/tools/release_script/format_files/0_common_files/languages/japanese.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/japanese.json
@@ -261,7 +261,9 @@
             "display_on_info_area": "情報エリアへの表示",
             "opening_name": "定石",
             "principal_variation": "最善筋",
-            "timer": "タイマー"
+            "timer": "タイマー",
+            "timer_time_limit": "時間制限",
+            "timer_time_limit_none": "なし"
         },
         "graph": {
             "display_on_graph_area": "グラフエリアへの表示",
@@ -340,7 +342,10 @@
         "forced_finished": "強制進行終了",
         "playing": "対局中",
         "analyzing": "分析中",
-        "calculation_stopped": "計算停止中"
+        "calculation_stopped": "計算停止中",
+        "timer_start": "開始",
+        "timer_pause": "一時停止",
+        "timer_reset": "リセット"
     },
     "edit_board": {
         "player": "手番",

--- a/src/tools/release_script/format_files/0_common_files/languages/japanese.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/japanese.json
@@ -261,7 +261,7 @@
             "display_on_info_area": "情報エリアへの表示",
             "opening_name": "定石",
             "principal_variation": "最善筋",
-            "timer": "タイマー",
+            "timer": "タイマー (分)",
             "timer_time_limit": "時間制限",
             "timer_time_limit_none": "なし"
         },

--- a/src/tools/release_script/format_files/0_common_files/languages/simplified_chinese.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/simplified_chinese.json
@@ -261,7 +261,9 @@
             "display_on_info_area": "情报显示",
             "opening_name": "定式名",
             "principal_variation": "AI推荐变化",
-            "timer": "计时器"
+            "timer": "计时器",
+            "timer_time_limit": "时间限制",
+            "timer_time_limit_none": "无"
         },
         "graph": {
             "display_on_graph_area": "图像显示",
@@ -340,7 +342,10 @@
         "forced_finished": "强制进行结束",
         "playing": "对局中",
         "analyzing": "分析中",
-        "calculation_stopped": "计算已停止"
+        "calculation_stopped": "计算已停止",
+        "timer_start": "开始",
+        "timer_pause": "暂停",
+        "timer_reset": "重置"
     },
     "edit_board": {
         "player": "玩家",

--- a/src/tools/release_script/format_files/0_common_files/languages/simplified_chinese.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/simplified_chinese.json
@@ -261,7 +261,7 @@
             "display_on_info_area": "情报显示",
             "opening_name": "定式名",
             "principal_variation": "AI推荐变化",
-            "timer": "计时器",
+            "timer": "计时器 (分)",
             "timer_time_limit": "时间限制",
             "timer_time_limit_none": "无"
         },

--- a/src/tools/release_script/format_files/0_common_files/languages/traditional_chinese_taiwan.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/traditional_chinese_taiwan.json
@@ -259,7 +259,7 @@
             "display_on_info_area": "顯示於資訊區",
             "opening_name": "定石名",
             "principal_variation": "最佳變化路線",
-            "timer": "計時器",
+            "timer": "計時器 (分)",
             "timer_time_limit": "時間限制",
             "timer_time_limit_none": "無"
         },

--- a/src/tools/release_script/format_files/0_common_files/languages/traditional_chinese_taiwan.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/traditional_chinese_taiwan.json
@@ -259,7 +259,9 @@
             "display_on_info_area": "顯示於資訊區",
             "opening_name": "定石名",
             "principal_variation": "最佳變化路線",
-            "timer": "計時器"
+            "timer": "計時器",
+            "timer_time_limit": "時間限制",
+            "timer_time_limit_none": "無"
         },
         "graph": {
             "display_on_graph_area": "顯示於圖表區",
@@ -338,7 +340,10 @@
         "forced_finished": "強制進行結束",
         "playing": "對局中",
         "analyzing": "分析中",
-        "calculation_stopped": "計算已停止"
+        "calculation_stopped": "計算已停止",
+        "timer_start": "開始",
+        "timer_pause": "暫停",
+        "timer_reset": "重置"
     },
     "edit_board": {
         "player": "玩家",


### PR DESCRIPTION
 Details:
  1. Adds Start, Pause, and Reset buttons for the timer. If the current turn is controlled by the AI and the       timer has never been started, the timer starts automatically with the same behavior as pressing Start. If the
  current turn is controlled by the user, the timer must be started manually.
  2. Adds a time limit setting from 1 to 60 minutes in whole-minute steps. The far-left option is No Time Limit.
  3. When a time limit is set, a player's timer turns red once that player reaches the limit.
  4. Updates the Timer item in the Display > Info menu to use the same checked-slider style as Best Line,
  including a disabled mark and a No Time Limit value.
  5. Saves and loads the timer time-limit setting through normal settings and display profiles.

  Notes:
  1. When AI Focus is enabled, the timer UI is hidden so it does not conflict with the AI Focus display.
  2. Timer elapsed time is settled before graph navigation changes the current position, so time already spent at
  the current node is not lost when moving backward or forward.
  3. Timer accumulation is guarded by the current board, player, and graph branch, so time is not added while
  reviewing non-current positions.
  4. AI auto-start only happens before the timer has ever been started. If the user manually pauses during an AI
  turn, the AI will not automatically resume the timer on the next frame.

 Generated-by: GPT-5.5 Codex
  Assisted-by: RuiRui
  Signed-off-by: RuiRui
<img width="985" height="419" alt="Screenshot 2026-06-30 175453" src="https://github.com/user-attachments/assets/fbc9704d-7035-4383-ae27-125f8fd6e142" />
<img width="1451" height="690" alt="Screenshot 2026-06-30 175512" src="https://github.com/user-attachments/assets/d796e932-03cb-4ad3-b687-1e5cb93c3146" />

