### PR TITLE
Fix #627

### DIFF
--- a/src/gui/function/const/info.hpp
+++ b/src/gui/function/const/info.hpp
@@ -13,7 +13,7 @@
 #include "./../../../engine/setting.hpp"
 #include "settings.hpp"
 
-#define EGAROUCID_GUI_VERSION "2"
+#define EGAROUCID_GUI_VERSION "2 20260717_Issue627"
 #if USE_BETA_VERSION
     #if GUI_PORTABLE_MODE
         const String EGAROUCID_VERSION = Unicode::Widen(EGAROUCID_ENGINE_VERSION + (std::string)"." + EGAROUCID_GUI_VERSION + (std::string)" " + EGAROUCID_ENGINE_ENV_VERSION + (std::string)" Portable" + (std::string)" beta");

--- a/src/gui/function/const/info.hpp
+++ b/src/gui/function/const/info.hpp
@@ -13,7 +13,7 @@
 #include "./../../../engine/setting.hpp"
 #include "settings.hpp"
 
-#define EGAROUCID_GUI_VERSION "2 20260717_Issue627"
+#define EGAROUCID_GUI_VERSION "2 20260718_Issue627"
 #if USE_BETA_VERSION
     #if GUI_PORTABLE_MODE
         const String EGAROUCID_VERSION = Unicode::Widen(EGAROUCID_ENGINE_VERSION + (std::string)"." + EGAROUCID_GUI_VERSION + (std::string)" " + EGAROUCID_ENGINE_ENV_VERSION + (std::string)" Portable" + (std::string)" beta");

--- a/src/gui/silent_load_scene.hpp
+++ b/src/gui/silent_load_scene.hpp
@@ -13,6 +13,12 @@
 #include <future>
 #include "./../engine/engine_all.hpp"
 #include "function/function_all.hpp"
+#if SIV3D_PLATFORM(WINDOWS)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#endif
 
 std::string get_default_language() {
     std::string default_language = System::DefaultLanguage().narrow();
@@ -705,6 +711,32 @@ bool is_window_bounds_in_work_area(const Rect& window_bounds) {
     return false;
 }
 
+bool is_windows_7_or_earlier() {
+#if SIV3D_PLATFORM(WINDOWS)
+    using RtlGetVersionFunc = LONG(WINAPI*)(OSVERSIONINFOW*);
+    const HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
+    if (!ntdll) {
+        return false;
+    }
+
+    const auto rtl_get_version = reinterpret_cast<RtlGetVersionFunc>(::GetProcAddress(ntdll, "RtlGetVersion"));
+    if (!rtl_get_version) {
+        return false;
+    }
+
+    OSVERSIONINFOW version_info{};
+    version_info.dwOSVersionInfoSize = sizeof(version_info);
+    if (rtl_get_version(&version_info) != 0) {
+        return false;
+    }
+
+    return version_info.dwMajorVersion < 6 ||
+        (version_info.dwMajorVersion == 6 && version_info.dwMinorVersion <= 1);
+#else
+    return false;
+#endif
+}
+
 void apply_default_window_settings(Window_state* window_state) {
     Window::Resize(Size{ WINDOW_SIZE_X, WINDOW_SIZE_Y }, Centering::Yes);
     window_state->window_scale = 1.0;
@@ -714,6 +746,10 @@ void apply_default_window_settings(Window_state* window_state) {
 }
 
 void apply_saved_window_settings(const Settings& settings, Window_state* window_state) {
+    if (is_windows_7_or_earlier()) {
+        return;
+    }
+
     const double window_scale = std::clamp(settings.window_scale, WINDOW_SCALE_MIN, WINDOW_SCALE_MAX);
     const Size saved_window_size = get_scaled_window_size(window_scale);
     if (!Window::Resize(saved_window_size, settings.has_window_pos ? Centering::No : Centering::Yes)) {
@@ -772,6 +808,9 @@ public:
             if (silent_load_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
                 load_code = silent_load_future.get();
                 loaded = load_code == ERR_OK;
+                if (loaded) {
+                    apply_saved_window_settings(getData().settings, &getData().window_state);
+                }
                 loading = false;
             }
         } else {

--- a/src/gui/silent_load_scene.hpp
+++ b/src/gui/silent_load_scene.hpp
@@ -772,10 +772,6 @@ public:
             if (silent_load_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
                 load_code = silent_load_future.get();
                 loaded = load_code == ERR_OK;
-                if (loaded) {
-                    // Temporarily ignore saved window size and position at startup.
-                    apply_default_window_settings(&getData().window_state);
-                }
                 loading = false;
             }
         } else {

--- a/src/gui/silent_load_scene.hpp
+++ b/src/gui/silent_load_scene.hpp
@@ -773,7 +773,8 @@ public:
                 load_code = silent_load_future.get();
                 loaded = load_code == ERR_OK;
                 if (loaded) {
-                    apply_saved_window_settings(getData().settings, &getData().window_state);
+                    // Temporarily ignore saved window size and position at startup.
+                    apply_default_window_settings(&getData().window_state);
                 }
                 loading = false;
             }


### PR DESCRIPTION
**概要**
Windows 7 以前の環境で、起動時にウィンドウが表示されない場合がある問題( #627 )への対策を追加しました。

**変更内容**
- 起動時に保存済みのウィンドウサイズ・位置を復元する処理を、Windows 7 以前では実行しないようにしました。
- Windows のバージョン判定には `RtlGetVersion` を使用し、マニフェスト依存でバージョンが丸められる問題を避けています。
- Windows 8 以降および Windows 以外の環境では、従来通り保存済みのウィンドウサイズ・位置を復元します。

**背景**
Windows 7 on Pentium B960 環境で、タスクバーにはアイコンが出るもののウィンドウが表示されないという報告がありました。直近で追加した起動時のウィンドウサイズ・位置復元処理を無効化したビルドでは起動できたため、古い Windows 環境では起動直後の `Window::Resize()` / `Window::SetPos()` が問題になる可能性があると判断しました。

**確認**
- Windows 7 以前では、起動時の保存済みウィンドウ設定復元をスキップします。
- Windows 8 以降では既存動作を維持します。


**Summary**
Added a workaround for an issue #627 where the application window may not appear on Windows 7 or earlier during startup.

**Changes**
- Skip restoring the saved window size and position on Windows 7 or earlier.
- Use `RtlGetVersion` for runtime Windows version detection to avoid manifest-dependent version reporting issues.
- Keep the existing saved window size/position restore behavior on Windows 8 or later and non-Windows platforms.

**Background**
A user reported that on Windows 7 with a Pentium B960, the application icon appeared on the taskbar but the window itself did not show up. A test build with the startup window size/position restore disabled launched successfully, so the startup-time `Window::Resize()` / `Window::SetPos()` calls are likely problematic on older Windows environments.

**Validation**
- Saved window restoration is skipped on Windows 7 or earlier.
- Existing behavior is preserved on Windows 8 or later.

## AI-assisted contribution checklist

Assisted-by: Codex 5.5
Signed-off-by: Nyanyan

- [x] I have read and agree to follow the [AI-assisted contributions policy](https://github.com/Nyanyan/Egaroucid#ai-assisted-contributions).
  Japanese Translation: [AIを活用した貢献に関するポリシー](https://github.com/Nyanyan/Egaroucid#ai-assisted-contributions) を読み、その内容に同意し、従います。
- [x] I have disclosed whether AI tools were used in this pull request.
  Japanese Translation: このプルリクエストでAIツールを使用したかどうかを明示しました。
- [x] If AI tools were used, I have manually reviewed and tested the generated or assisted changes.
  Japanese Translation: AIツールを使用した場合、生成または支援された変更内容を手動で確認し、テストしました。

