### PR TITLE
feat(gui): add cumulative error through current move

### DIFF
--- a/bin/resources/languages/english.json
+++ b/bin/resources/languages/english.json
@@ -272,7 +272,8 @@
             "value": "Evaluation",
             "sum_of_loss": "Sum of Loss",
             "show_random_board_graph": "Show Random Position Graph",
-            "endgame_error": "Endgame Error",
+            "endgame_error": "Cumulative Error",
+            "endgame_error_1_to_current": "Move 1-Current",
             "endgame_error_40_to_60": "Move 40-60",
             "endgame_error_41_to_60": "Move 41-60"
         },

--- a/bin/resources/languages/japanese.json
+++ b/bin/resources/languages/japanese.json
@@ -274,7 +274,8 @@
             "value": "評価値",
             "sum_of_loss": "累積石損",
             "show_random_board_graph": "ランダム局面のグラフを表示",
-            "endgame_error": "終盤石損",
+            "endgame_error": "累積石損",
+            "endgame_error_1_to_current": "1手目~現在",
             "endgame_error_40_to_60": "40~60手目",
             "endgame_error_41_to_60": "41~60手目"
         },

--- a/bin/resources/languages/simplified_chinese.json
+++ b/bin/resources/languages/simplified_chinese.json
@@ -274,7 +274,8 @@
             "value": "双方估值变化",
             "sum_of_loss": "双方累计子损",
             "show_random_board_graph": "显示随机局面图像",
-            "endgame_error": "终局错误",
+            "endgame_error": "累计子损",
+            "endgame_error_1_to_current": "1~当前局面",
             "endgame_error_40_to_60": "40~60手",
             "endgame_error_41_to_60": "41~60手"
         },

--- a/bin/resources/languages/traditional_chinese_taiwan.json
+++ b/bin/resources/languages/traditional_chinese_taiwan.json
@@ -272,7 +272,8 @@
             "value": "評分值",
             "sum_of_loss": "總損失值",
             "show_random_board_graph": "顯示隨機局面圖表",
-            "endgame_error": "終局錯誤",
+            "endgame_error": "累計子損",
+            "endgame_error_1_to_current": "1~目前局面",
             "endgame_error_40_to_60": "40~60手",
             "endgame_error_41_to_60": "41~60手"
         },

--- a/src/gui/close_scene.hpp
+++ b/src/gui/close_scene.hpp
@@ -141,6 +141,7 @@ void save_settings(Menu_elements menu_elements, Settings settings, Directories d
     setting_json[U"generate_random_board_score_range_max"] = menu_elements.generate_random_board_score_range_max;
     setting_json[U"show_hint_level"] = menu_elements.show_hint_level;
     setting_json[U"show_endgame_error"] = menu_elements.show_endgame_error;
+    setting_json[U"show_endgame_error_1_to_current"] = menu_elements.show_endgame_error_1_to_current;
     setting_json[U"show_endgame_error_40_to_60"] = menu_elements.show_endgame_error_40_to_60;
     setting_json[U"show_endgame_error_41_to_60"] = menu_elements.show_endgame_error_41_to_60;
     setting_json[U"hint_colorize"] = menu_elements.hint_colorize;

--- a/src/gui/function/const/gui_common.hpp
+++ b/src/gui/function/const/gui_common.hpp
@@ -618,6 +618,7 @@ struct Settings {
     int generate_random_board_score_range_max;
     bool show_hint_level;
     bool show_endgame_error;
+    bool show_endgame_error_1_to_current;
     bool show_endgame_error_40_to_60;
     bool show_endgame_error_41_to_60;
     bool hint_colorize;
@@ -759,6 +760,7 @@ struct Menu_elements {
     int pv_length;
     bool show_value_when_ai_calculating;
     bool show_endgame_error;
+    bool show_endgame_error_1_to_current;
     bool show_endgame_error_40_to_60;
     bool show_endgame_error_41_to_60;
     bool hint_colorize;
@@ -921,6 +923,7 @@ struct Menu_elements {
         pv_length = settings->pv_length;
         show_value_when_ai_calculating = settings->show_value_when_ai_calculating;
         show_endgame_error = settings->show_endgame_error;
+        show_endgame_error_1_to_current = settings->show_endgame_error_1_to_current;
         show_endgame_error_40_to_60 = settings->show_endgame_error_40_to_60;
         show_endgame_error_41_to_60 = settings->show_endgame_error_41_to_60;
         hint_colorize = settings->hint_colorize;

--- a/src/gui/function/display_profile.hpp
+++ b/src/gui/function/display_profile.hpp
@@ -50,6 +50,7 @@ struct Display_profile_values {
     int pv_length{ 7 };
     bool show_value_when_ai_calculating{ false };
     bool show_endgame_error{ false };
+    bool show_endgame_error_1_to_current{ false };
     bool show_endgame_error_40_to_60{ true };
     bool show_endgame_error_41_to_60{ false };
     bool hint_colorize{ false };
@@ -92,7 +93,8 @@ inline void normalize_display_profile_values(Display_profile_values* values) {
         values->show_graph_value = true;
         values->show_graph_sum_of_loss = false;
     }
-    if (values->show_endgame_error_40_to_60 == values->show_endgame_error_41_to_60) {
+    if ((int)values->show_endgame_error_1_to_current + (int)values->show_endgame_error_40_to_60 + (int)values->show_endgame_error_41_to_60 != 1) {
+        values->show_endgame_error_1_to_current = false;
         values->show_endgame_error_40_to_60 = true;
         values->show_endgame_error_41_to_60 = false;
     }
@@ -135,6 +137,7 @@ inline Display_profile_values to_display_profile_values(const Settings& settings
     values.pv_length = settings.pv_length;
     values.show_value_when_ai_calculating = settings.show_value_when_ai_calculating;
     values.show_endgame_error = settings.show_endgame_error;
+    values.show_endgame_error_1_to_current = settings.show_endgame_error_1_to_current;
     values.show_endgame_error_40_to_60 = settings.show_endgame_error_40_to_60;
     values.show_endgame_error_41_to_60 = settings.show_endgame_error_41_to_60;
     values.hint_colorize = settings.hint_colorize;
@@ -179,6 +182,7 @@ inline Display_profile_values to_display_profile_values(const Menu_elements& men
     values.pv_length = menu_elements.pv_length;
     values.show_value_when_ai_calculating = menu_elements.show_value_when_ai_calculating;
     values.show_endgame_error = menu_elements.show_endgame_error;
+    values.show_endgame_error_1_to_current = menu_elements.show_endgame_error_1_to_current;
     values.show_endgame_error_40_to_60 = menu_elements.show_endgame_error_40_to_60;
     values.show_endgame_error_41_to_60 = menu_elements.show_endgame_error_41_to_60;
     values.hint_colorize = menu_elements.hint_colorize;
@@ -224,6 +228,7 @@ inline void apply_display_profile_values(const Display_profile_values& values, S
     settings->pv_length = normalized_values.pv_length;
     settings->show_value_when_ai_calculating = normalized_values.show_value_when_ai_calculating;
     settings->show_endgame_error = normalized_values.show_endgame_error;
+    settings->show_endgame_error_1_to_current = normalized_values.show_endgame_error_1_to_current;
     settings->show_endgame_error_40_to_60 = normalized_values.show_endgame_error_40_to_60;
     settings->show_endgame_error_41_to_60 = normalized_values.show_endgame_error_41_to_60;
     settings->hint_colorize = normalized_values.hint_colorize;
@@ -267,6 +272,7 @@ inline void apply_display_profile_values(const Display_profile_values& values, M
     menu_elements->pv_length = normalized_values.pv_length;
     menu_elements->show_value_when_ai_calculating = normalized_values.show_value_when_ai_calculating;
     menu_elements->show_endgame_error = normalized_values.show_endgame_error;
+    menu_elements->show_endgame_error_1_to_current = normalized_values.show_endgame_error_1_to_current;
     menu_elements->show_endgame_error_40_to_60 = normalized_values.show_endgame_error_40_to_60;
     menu_elements->show_endgame_error_41_to_60 = normalized_values.show_endgame_error_41_to_60;
     menu_elements->hint_colorize = normalized_values.hint_colorize;
@@ -336,6 +342,7 @@ inline void export_display_profile_json(JSON& json, const Display_profile_values
     json[U"pv_length"] = normalized_values.pv_length;
     json[U"show_value_when_ai_calculating"] = normalized_values.show_value_when_ai_calculating;
     json[U"show_endgame_error"] = normalized_values.show_endgame_error;
+    json[U"show_endgame_error_1_to_current"] = normalized_values.show_endgame_error_1_to_current;
     json[U"show_endgame_error_40_to_60"] = normalized_values.show_endgame_error_40_to_60;
     json[U"show_endgame_error_41_to_60"] = normalized_values.show_endgame_error_41_to_60;
     json[U"hint_colorize"] = normalized_values.hint_colorize;
@@ -386,6 +393,7 @@ inline bool load_display_profile_values(const FilePath& path, Display_profile_va
     import_display_profile_int(json, U"pv_length", &values->pv_length);
     import_display_profile_bool(json, U"show_value_when_ai_calculating", &values->show_value_when_ai_calculating);
     import_display_profile_bool(json, U"show_endgame_error", &values->show_endgame_error);
+    import_display_profile_bool(json, U"show_endgame_error_1_to_current", &values->show_endgame_error_1_to_current);
     import_display_profile_bool(json, U"show_endgame_error_40_to_60", &values->show_endgame_error_40_to_60);
     import_display_profile_bool(json, U"show_endgame_error_41_to_60", &values->show_endgame_error_41_to_60);
     import_display_profile_bool(json, U"hint_colorize", &values->hint_colorize);
@@ -441,6 +449,7 @@ inline bool equals_display_profile_values(const Display_profile_values& lhs, con
     if (lhs.pv_length != rhs.pv_length) return false;
     if (lhs.show_value_when_ai_calculating != rhs.show_value_when_ai_calculating) return false;
     if (lhs.show_endgame_error != rhs.show_endgame_error) return false;
+    if (lhs.show_endgame_error_1_to_current != rhs.show_endgame_error_1_to_current) return false;
     if (lhs.show_endgame_error_40_to_60 != rhs.show_endgame_error_40_to_60) return false;
     if (lhs.show_endgame_error_41_to_60 != rhs.show_endgame_error_41_to_60) return false;
     if (lhs.hint_colorize != rhs.hint_colorize) return false;

--- a/src/gui/function/graph.hpp
+++ b/src/gui/function/graph.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 #include "./../../engine/board.hpp"
 #include "language.hpp"
+#include "graph_error.hpp"
 #include "./const/gui_common.hpp"
 
 constexpr Color graph_color = Color(51, 51, 51);
@@ -75,7 +76,7 @@ private:
     double dx;
 
 public:
-    void draw(std::vector<History_elem> nodes1, std::vector<History_elem> nodes2, int n_discs, bool show_graph, int level, Font font, int color_type, bool show_graph_sum_of_loss, bool show_endgame_error, bool show_endgame_error_40_to_60, int graph_highlight_n_discs, int graph_value_start_n_discs) {
+    void draw(std::vector<History_elem> nodes1, std::vector<History_elem> nodes2, int n_discs, int graph_branch, bool show_graph, int level, Font font, int color_type, bool show_graph_sum_of_loss, bool show_endgame_error, bool show_endgame_error_1_to_current, bool show_endgame_error_40_to_60, int graph_highlight_n_discs, int graph_value_start_n_discs, int current_error_start_n_discs) {
         std::vector<History_elem> graph_nodes1 = nodes1;
         std::vector<History_elem> graph_nodes2 = nodes2;
         if (graph_value_start_n_discs != -1) {
@@ -137,17 +138,29 @@ public:
             }
         } else { // endgame error
             int endgame_error_black = 0, endgame_error_white = 0;
-            bool endgame_error_calculated = calc_endgame_error(graph_nodes1, graph_nodes2, &endgame_error_black, &endgame_error_white, show_endgame_error_40_to_60);
-            int endgame_error_cy = sy - 48;
-            int endgame_error_cx = sx + GRAPH_RECT_DX + GRAPH_RECT_WIDTH / 2;
+            bool endgame_error_calculated;
+            bool endgame_error_complete = true;
+            if (show_endgame_error_1_to_current) {
+                const Graph_error_result result = calc_current_endgame_error(nodes1, nodes2, graph_branch, n_discs, current_error_start_n_discs);
+                endgame_error_black = result.black;
+                endgame_error_white = result.white;
+                endgame_error_complete = result.complete;
+                endgame_error_calculated = true;
+            } else {
+                endgame_error_calculated = calc_endgame_error(graph_nodes1, graph_nodes2, &endgame_error_black, &endgame_error_white, show_endgame_error_40_to_60);
+            }
+            const int endgame_error_cy = sy - 44;
+            const int endgame_error_cx = sx + GRAPH_RECT_DX + GRAPH_RECT_WIDTH / 2;
             constexpr int ENDGAME_ERROR_DISC_RADIUS = 7;
-            font(language.get("display", "graph", "endgame_error")).draw(11, Arg::rightCenter(endgame_error_cx - 73, endgame_error_cy), Palette::White);
+            font(language.get("display", "graph", "endgame_error") + U": " + get_endgame_error_range_label(show_endgame_error_1_to_current, show_endgame_error_40_to_60)).draw(11, Arg::center(endgame_error_cx, endgame_error_cy - 16), Palette::White);
             Line(endgame_error_cx, endgame_error_cy - 7, endgame_error_cx, endgame_error_cy + 7).draw(2, graph_color);
             Circle(endgame_error_cx - 60, endgame_error_cy, ENDGAME_ERROR_DISC_RADIUS).draw(Palette::Black);
             Circle(endgame_error_cx + 60, endgame_error_cy, ENDGAME_ERROR_DISC_RADIUS).draw(Palette::White);
             if (endgame_error_calculated) {
-                font(-endgame_error_black).draw(16, Arg::rightCenter(endgame_error_cx - 10, endgame_error_cy), Palette::White);
-                font(-endgame_error_white).draw(16, Arg::leftCenter(endgame_error_cx + 10, endgame_error_cy), Palette::White);
+                // Loss is displayed as -error, so an incomplete error lower bound becomes "less than or equal".
+                const String incomplete_prefix = endgame_error_complete ? U"" : U"≤ ";
+                font(incomplete_prefix + Format(-endgame_error_black)).draw(16, Arg::rightCenter(endgame_error_cx - 10, endgame_error_cy), Palette::White);
+                font(incomplete_prefix + Format(-endgame_error_white)).draw(16, Arg::leftCenter(endgame_error_cx + 10, endgame_error_cy), Palette::White);
             } else {
                 font(U"-").draw(16, Arg::rightCenter(endgame_error_cx - 10, endgame_error_cy), Palette::White);
                 font(U"-").draw(16, Arg::leftCenter(endgame_error_cx + 10, endgame_error_cy), Palette::White);
@@ -406,6 +419,46 @@ private:
                 el.v *= -1;
             }
         }
+    }
+
+    String get_endgame_error_range_label(bool show_endgame_error_1_to_current, bool show_endgame_error_40_to_60) const {
+        if (show_endgame_error_1_to_current) {
+            return language.get("display", "graph", "endgame_error_1_to_current");
+        }
+        if (show_endgame_error_40_to_60) {
+            return language.get("display", "graph", "endgame_error_40_to_60");
+        }
+        return language.get("display", "graph", "endgame_error_41_to_60");
+    }
+
+    std::vector<Graph_error_sample> to_graph_error_samples(const std::vector<History_elem>& nodes) const {
+        std::vector<Graph_error_sample> result;
+        result.reserve(nodes.size());
+        for (const History_elem& node : nodes) {
+            result.emplace_back(Graph_error_sample{
+                node.board.n_discs(),
+                node.v,
+                -SCORE_MAX <= node.v && node.v <= SCORE_MAX
+            });
+        }
+        return result;
+    }
+
+    Graph_error_result calc_current_endgame_error(
+        const std::vector<History_elem>& nodes1,
+        const std::vector<History_elem>& nodes2,
+        int graph_branch,
+        int current_n_discs,
+        int start_n_discs
+    ) const {
+        const std::vector<Graph_error_sample> samples = get_current_error_samples(
+            to_graph_error_samples(nodes1),
+            to_graph_error_samples(nodes2),
+            graph_branch == GRAPH_MODE_INSPECT,
+            current_n_discs,
+            start_n_discs
+        );
+        return calc_current_error(samples, current_n_discs);
     }
 
     bool calc_endgame_error(std::vector<History_elem> nodes1, std::vector<History_elem> nodes2, int *endgame_error_black, int *endgame_error_white, bool show_endgame_error_40_to_60) {

--- a/src/gui/function/graph_error.hpp
+++ b/src/gui/function/graph_error.hpp
@@ -1,0 +1,94 @@
+/*
+    Egaroucid Project
+
+    @file graph_error.hpp
+        Current-position graph error calculation
+    @date 2026
+    @author Takuto Yamana
+    @license GPL-3.0-or-later
+*/
+
+#pragma once
+#include <algorithm>
+#include <vector>
+
+struct Graph_error_sample {
+    int n_discs;
+    int value;
+    bool value_available;
+};
+
+struct Graph_error_result {
+    int black{ 0 };
+    int white{ 0 };
+    bool complete{ true };
+};
+
+inline std::vector<Graph_error_sample> get_current_error_samples(
+    const std::vector<Graph_error_sample>& main_line,
+    const std::vector<Graph_error_sample>& inspect_line,
+    bool use_inspect_line,
+    int current_n_discs,
+    int start_n_discs = -1
+) {
+    std::vector<Graph_error_sample> result;
+    int inspect_start_n_discs = current_n_discs + 1;
+    if (use_inspect_line && !inspect_line.empty()) {
+        inspect_start_n_discs = inspect_line.front().n_discs;
+    }
+
+    for (const Graph_error_sample& sample : main_line) {
+        if (sample.n_discs < start_n_discs) {
+            continue;
+        }
+        if (sample.n_discs > current_n_discs || sample.n_discs >= inspect_start_n_discs) {
+            break;
+        }
+        result.emplace_back(sample);
+    }
+    if (use_inspect_line) {
+        for (const Graph_error_sample& sample : inspect_line) {
+            if (sample.n_discs < start_n_discs) {
+                continue;
+            }
+            if (sample.n_discs > current_n_discs) {
+                break;
+            }
+            result.emplace_back(sample);
+        }
+    }
+    return result;
+}
+
+inline Graph_error_result calc_current_error(
+    const std::vector<Graph_error_sample>& samples,
+    int current_n_discs
+) {
+    Graph_error_result result;
+    if (samples.empty()) {
+        return result;
+    }
+
+    int previous_value = samples.front().value_available ? samples.front().value : 0;
+    int previous_n_discs = samples.front().n_discs;
+    for (int i = 1; i < static_cast<int>(samples.size()); ++i) {
+        const Graph_error_sample& sample = samples[i];
+        if (sample.n_discs != previous_n_discs + 1) {
+            result.complete = false;
+        }
+        previous_n_discs = sample.n_discs;
+        if (!sample.value_available) {
+            result.complete = false;
+            continue;
+        }
+
+        const int error = sample.value - previous_value;
+        result.black += std::max(0, -error);
+        result.white += std::max(0, error);
+        previous_value = sample.value;
+    }
+    if (samples.back().n_discs < current_n_discs) {
+        result.complete = false;
+    }
+    return result;
+}

--- a/src/gui/function/menu_definition.hpp
+++ b/src/gui/function/menu_definition.hpp
@@ -172,6 +172,8 @@ Menu create_menu(Menu_elements* menu_elements, Resources *resources, Font font, 
                 side_menu.push(side_side_menu);
             menu_e.push(side_menu);
             side_menu.init_check(language.get("display", "graph", "endgame_error") + get_shortcut_key_info(U"show_endgame_error"), &menu_elements->show_endgame_error, menu_elements->show_endgame_error);
+                side_side_menu.init_radio(language.get("display", "graph", "endgame_error_1_to_current"), &menu_elements->show_endgame_error_1_to_current, menu_elements->show_endgame_error_1_to_current);
+                side_menu.push(side_side_menu);
                 side_side_menu.init_radio(language.get("display", "graph", "endgame_error_40_to_60"), &menu_elements->show_endgame_error_40_to_60, menu_elements->show_endgame_error_40_to_60);
                 side_menu.push(side_side_menu);
                 side_side_menu.init_radio(language.get("display", "graph", "endgame_error_41_to_60"), &menu_elements->show_endgame_error_41_to_60, menu_elements->show_endgame_error_41_to_60);

--- a/src/gui/main_scene.hpp
+++ b/src/gui/main_scene.hpp
@@ -417,9 +417,13 @@ public:
         }
 
         // graph drawing
-        const int graph_highlight_n_discs = get_marked_random_generated_position_n_discs();
-        const int graph_value_start_n_discs = get_graph_value_start_n_discs();
-        graph.draw(getData().graph_resources.nodes[0], getData().graph_resources.nodes[1], getData().graph_resources.n_discs, getData().menu_elements.show_graph, getData().menu_elements.level, getData().fonts.font, getData().menu_elements.change_color_type, getData().menu_elements.show_graph_sum_of_loss, getData().menu_elements.show_endgame_error, getData().menu_elements.show_endgame_error_40_to_60, graph_highlight_n_discs, graph_value_start_n_discs);
+        const int random_generated_start_n_discs = get_marked_random_generated_position_n_discs();
+        const int xot_start_n_discs = getData().graph_resources.xot_start_n_discs;
+        const int graph_highlight_n_discs = std::max(random_generated_start_n_discs, xot_start_n_discs);
+        const int identified_xot_graph_start_n_discs = random_generated_start_n_discs == -1 ? xot_start_n_discs : -1;
+        const int graph_value_start_n_discs = std::max(get_graph_value_start_n_discs(), identified_xot_graph_start_n_discs);
+        const int current_error_start_n_discs = graph_highlight_n_discs;
+        graph.draw(getData().graph_resources.nodes[0], getData().graph_resources.nodes[1], getData().graph_resources.n_discs, getData().graph_resources.branch, getData().menu_elements.show_graph, getData().menu_elements.level, getData().fonts.font, getData().menu_elements.change_color_type, getData().menu_elements.show_graph_sum_of_loss, getData().menu_elements.show_endgame_error, getData().menu_elements.show_endgame_error_1_to_current, getData().menu_elements.show_endgame_error_40_to_60, graph_highlight_n_discs, graph_value_start_n_discs, current_error_start_n_discs);
 
         // info drawing
         int playing_mode = PLAYING_MODE_NONE;

--- a/src/gui/silent_load_scene.hpp
+++ b/src/gui/silent_load_scene.hpp
@@ -120,6 +120,7 @@ void init_default_settings(const Directories* directories, const Resources* reso
     settings->generate_random_board_score_range_max = 64;
     settings->show_hint_level = true;
     settings->show_endgame_error = false;
+    settings->show_endgame_error_1_to_current = false;
     settings->show_endgame_error_40_to_60 = true;
     settings->show_endgame_error_41_to_60 = false;
     settings->hint_colorize = false;
@@ -539,13 +540,17 @@ void init_settings(const Directories* directories, const Resources* resources, S
         if (init_settings_import_bool(setting_json, U"show_endgame_error", &settings->show_endgame_error) != ERR_OK) {
             std::cerr << "err54" << std::endl;
         }
+        if (init_settings_import_bool(setting_json, U"show_endgame_error_1_to_current", &settings->show_endgame_error_1_to_current) != ERR_OK) {
+            settings->show_endgame_error_1_to_current = false;
+        }
         if (init_settings_import_bool(setting_json, U"show_endgame_error_40_to_60", &settings->show_endgame_error_40_to_60) != ERR_OK) {
             std::cerr << "err54-1" << std::endl;
         }
         if (init_settings_import_bool(setting_json, U"show_endgame_error_41_to_60", &settings->show_endgame_error_41_to_60) != ERR_OK) {
             settings->show_endgame_error_41_to_60 = !settings->show_endgame_error_40_to_60;
         }
-        if (settings->show_endgame_error_40_to_60 == settings->show_endgame_error_41_to_60) {
+        if ((int)settings->show_endgame_error_1_to_current + (int)settings->show_endgame_error_40_to_60 + (int)settings->show_endgame_error_41_to_60 != 1) {
+            settings->show_endgame_error_1_to_current = false;
             settings->show_endgame_error_40_to_60 = true;
             settings->show_endgame_error_41_to_60 = false;
         }

--- a/src/tools/release_script/format_files/0_common_files/languages/english.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/english.json
@@ -272,7 +272,8 @@
             "value": "Evaluation",
             "sum_of_loss": "Sum of Loss",
             "show_random_board_graph": "Show Random Position Graph",
-            "endgame_error": "Endgame Error",
+            "endgame_error": "Cumulative Error",
+            "endgame_error_1_to_current": "Move 1-Current",
             "endgame_error_40_to_60": "Move 40-60",
             "endgame_error_41_to_60": "Move 41-60"
         },

--- a/src/tools/release_script/format_files/0_common_files/languages/japanese.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/japanese.json
@@ -274,7 +274,8 @@
             "value": "評価値",
             "sum_of_loss": "累積石損",
             "show_random_board_graph": "ランダム局面のグラフを表示",
-            "endgame_error": "終盤石損",
+            "endgame_error": "累積石損",
+            "endgame_error_1_to_current": "1手目~現在",
             "endgame_error_40_to_60": "40~60手目",
             "endgame_error_41_to_60": "41~60手目"
         },

--- a/src/tools/release_script/format_files/0_common_files/languages/simplified_chinese.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/simplified_chinese.json
@@ -274,7 +274,8 @@
             "value": "双方估值变化",
             "sum_of_loss": "双方累计子损",
             "show_random_board_graph": "显示随机局面图像",
-            "endgame_error": "终局错误",
+            "endgame_error": "累计子损",
+            "endgame_error_1_to_current": "1~当前局面",
             "endgame_error_40_to_60": "40~60手",
             "endgame_error_41_to_60": "41~60手"
         },

--- a/src/tools/release_script/format_files/0_common_files/languages/traditional_chinese_taiwan.json
+++ b/src/tools/release_script/format_files/0_common_files/languages/traditional_chinese_taiwan.json
@@ -272,7 +272,8 @@
             "value": "評分值",
             "sum_of_loss": "總損失值",
             "show_random_board_graph": "顯示隨機局面圖表",
-            "endgame_error": "終局錯誤",
+            "endgame_error": "累計子損",
+            "endgame_error_1_to_current": "1~目前局面",
             "endgame_error_40_to_60": "40~60手",
             "endgame_error_41_to_60": "41~60手"
         },


### PR DESCRIPTION
This PR expands the current stone loss range from 40–60 to 1–current.
It was written with reference to Othello Sensei’s code. https://github.com/borassi/othello-sensei
The program compiled successfully, and the graph in XOT works as expected.
<img width="529" height="216" alt="image" src="https://github.com/user-attachments/assets/f04618af-10aa-4901-b463-5c8ba8885aff" />
<img width="988" height="827" alt="image" src="https://github.com/user-attachments/assets/c487f986-2d82-4f58-ac3e-945ff95a90e7" />
<img width="666" height="187" alt="image" src="https://github.com/user-attachments/assets/1455d4bc-ed8f-434d-bc9b-d71b615fa38a" />

Generated-by: GPT-5.6-sol Codex
Assisted-by: RuiRui
Signed-off-by: RuiRui
